### PR TITLE
[codex] Add API coverage report artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ permissions:
 
 jobs:
   api:
-    name: api (Scala) format, compile & test
+    name: api (Scala) format, compile, test & coverage
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -51,5 +51,13 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-sbt-
 
-      - name: Format check, compile & test (apps/api)
-        run: nix develop .#scala --command bash -c 'cd apps/api && sbt -batch -no-colors scalafmtCheckAll test'
+      - name: Format check, compile, test & coverage (apps/api)
+        run: nix develop .#scala --command bash -c 'cd apps/api && sbt -batch -no-colors scalafmtCheckAll coverage test coverageAggregate'
+
+      - name: Upload coverage report
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: api-scoverage-report
+          path: apps/api/target/scala-*/scoverage-report/**
+          if-no-files-found: error
+          retention-days: 14

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,4 +52,4 @@ jobs:
             ${{ runner.os }}-sbt-
 
       - name: Format check, compile & test (apps/api)
-        run: nix develop .#scala --command bash -c 'cd apps/api && sbt -batch -no-colors scalafmtCheckAll test'
+        run: nix develop .#scala --command bash -c 'cd apps/api && sbt -batch -no-colors domain/scalafmtCheckAll application/scalafmtCheckAll infrastructure/scalafmtCheckAll test'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ permissions:
 
 jobs:
   api:
-    name: api (Scala) compile & test
+    name: api (Scala) format, compile & test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -47,9 +47,9 @@ jobs:
           path: |
             ~/.sbt
             ~/.cache/coursier
-          key: ${{ runner.os }}-sbt-${{ hashFiles('apps/api/build.sbt', 'apps/api/project/build.properties') }}
+          key: ${{ runner.os }}-sbt-${{ hashFiles('apps/api/build.sbt', 'apps/api/project/build.properties', 'apps/api/project/plugins.sbt', 'apps/api/.scalafmt.conf') }}
           restore-keys: |
             ${{ runner.os }}-sbt-
 
-      - name: Compile & test (apps/api)
-        run: nix develop .#scala --command bash -c 'cd apps/api && sbt -batch -no-colors test'
+      - name: Format check, compile & test (apps/api)
+        run: nix develop .#scala --command bash -c 'cd apps/api && sbt -batch -no-colors scalafmtCheckAll test'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,9 @@ jobs:
             ${{ runner.os }}-sbt-
 
       - name: Format check, compile, test & coverage (apps/api)
-        run: nix develop .#scala --command bash -c 'cd apps/api && sbt -batch -no-colors scalafmtCheckAll coverage test coverageAggregate'
+        run: |
+          nix develop .#scala --command bash -c 'cd apps/api && sbt -batch -no-colors scalafmtCheckAll clean'
+          nix develop .#scala --command bash -c 'cd apps/api && sbt -batch -no-colors coverage test coverageAggregate'
 
       - name: Upload coverage report
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,4 +52,4 @@ jobs:
             ${{ runner.os }}-sbt-
 
       - name: Format check, compile & test (apps/api)
-        run: nix develop .#scala --command bash -c 'cd apps/api && sbt -batch -no-colors domain/scalafmtCheckAll application/scalafmtCheckAll infrastructure/scalafmtCheckAll test'
+        run: nix develop .#scala --command bash -c 'cd apps/api && sbt -batch -no-colors scalafmtCheckAll test'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@
 
 ## Build, Test, and Development Commands
 - 開発環境: ルートで `nix develop`（flake で JDK 25 / sbt / Node / Rust を固定。Scala 3.8 系は JDK 17+ 必須なので JDK は nix で揃える）。以降のコマンドは dev shell 内で実行する。
-- API(Scala): sbt ビルドルートは `apps/api`。`cd apps/api` してから `sbt compile` / `sbt test`。集約カバレッジ取得は `sbt coverage test coverageAggregate`（HTML は `target/scala-*/scoverage-report/`）。純粋ドメインだけは `sbt domain/test`。`api/run` 等は今後追加。
+- API(Scala): sbt ビルドルートは `apps/api`。`cd apps/api` してから `sbt compile` / `sbt test`。集約カバレッジ取得は `sbt clean` 後に `sbt coverage test coverageAggregate`（HTML は `target/scala-*/scoverage-report/`）。純粋ドメインだけは `sbt domain/test`。`api/run` 等は今後追加。
 - RMU(Rust): `cd apps/rmu` で `cargo build` / `cargo test`（実装はタスク3以降）。
 - UI: `apps/ui` で `pnpm install`、各 app で `pnpm dev` / `pnpm build` / `pnpm test` / `pnpm lint`。
 - 型生成: API の OpenAPI から `packages/api-client` を再生成（`pnpm gen:api`）。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@
 
 ## Build, Test, and Development Commands
 - 開発環境: ルートで `nix develop`（flake で JDK 25 / sbt / Node / Rust を固定。Scala 3.8 系は JDK 17+ 必須なので JDK は nix で揃える）。以降のコマンドは dev shell 内で実行する。
-- API(Scala): sbt ビルドルートは `apps/api`。`cd apps/api` してから `sbt compile` / `sbt test`。純粋ドメインだけは `sbt domain/test`。`api/run` 等は今後追加。
+- API(Scala): sbt ビルドルートは `apps/api`。`cd apps/api` してから `sbt compile` / `sbt test`。集約カバレッジ取得は `sbt coverage test coverageAggregate`（HTML は `target/scala-*/scoverage-report/`）。純粋ドメインだけは `sbt domain/test`。`api/run` 等は今後追加。
 - RMU(Rust): `cd apps/rmu` で `cargo build` / `cargo test`（実装はタスク3以降）。
 - UI: `apps/ui` で `pnpm install`、各 app で `pnpm dev` / `pnpm build` / `pnpm test` / `pnpm lint`。
 - 型生成: API の OpenAPI から `packages/api-client` を再生成（`pnpm gen:api`）。

--- a/apps/api/.scalafmt.conf
+++ b/apps/api/.scalafmt.conf
@@ -1,0 +1,9 @@
+version = "3.9.10"
+runner.dialect = scala3
+
+maxColumn = 100
+align.preset = more
+continuationIndent.defnSite = 2
+continuationIndent.callSite = 2
+docstrings.style = Asterisk
+rewrite.trailingCommas.style = keep

--- a/apps/api/.scalafmt.conf
+++ b/apps/api/.scalafmt.conf
@@ -2,7 +2,6 @@ version = "3.9.10"
 runner.dialect = scala3
 
 maxColumn = 100
-align.preset = more
 continuationIndent.defnSite = 2
 continuationIndent.callSite = 2
 docstrings.style = Asterisk

--- a/apps/api/application/src/main/scala/morecat/application/ArticleCommandService.scala
+++ b/apps/api/application/src/main/scala/morecat/application/ArticleCommandService.scala
@@ -38,7 +38,7 @@ final class ArticleCommandService(store: ArticleEventStore, clock: ServerClock):
       _ <-
         if events.isEmpty then store.createDraft(command.articleId, event).mapError(toCommandError)
           .catchAll(recoverCreateDraftConflict(command.articleId, event))
-        else if events.length == 1 && events.headOption.exists(_.event == event) then ZIO.unit
+        else if hasSameInitialDraft(events, event) then ZIO.unit
         else ZIO.fail(CommandError.VersionConflict)
     yield ()
 
@@ -47,17 +47,15 @@ final class ArticleCommandService(store: ArticleEventStore, clock: ServerClock):
       events <- store.load(command.articleId).mapError(toCommandError)
       result <-
         if events.isEmpty then ZIO.fail(CommandError.ArticleNotFound)
-        else if alreadyPublished(events) && isIdempotentPublishRetry(events, command.expectedVersion) then
-          ZIO.succeed(PublishResult.AlreadyPublished)
-        else if currentVersion(events) != command.expectedVersion then ZIO.fail(CommandError.VersionConflict)
         else if alreadyPublished(events) then ZIO.succeed(PublishResult.AlreadyPublished)
+        else if currentVersion(events) != command.expectedVersion then ZIO.fail(CommandError.VersionConflict)
         else
           for
             publishedAt <- clock.nowMillis
             _ <- store
               .append(command.articleId, command.expectedVersion, ArticlePublished(publishedAt))
               .mapError(toCommandError)
-              .catchAll(recoverPublishConflict(command.articleId, command.expectedVersion))
+              .catchAll(recoverPublishConflict(command.articleId))
           yield PublishResult.Published
     yield result
 
@@ -68,19 +66,18 @@ final class ArticleCommandService(store: ArticleEventStore, clock: ServerClock):
     error match
       case CommandError.SlugConflict | CommandError.VersionConflict =>
         store.load(articleId).mapError(toCommandError).flatMap { events =>
-          if events.length == 1 && events.headOption.exists(_.event == event) then ZIO.unit
+          if hasSameInitialDraft(events, event) then ZIO.unit
           else ZIO.fail(error)
         }
       case other => ZIO.fail(other)
 
   private def recoverPublishConflict(
       articleId: ArticleId,
-      expectedVersion: Long,
   )(error: CommandError): IO[CommandError, Unit] =
     error match
       case CommandError.VersionConflict =>
         store.load(articleId).mapError(toCommandError).flatMap { events =>
-          if alreadyPublished(events) && isIdempotentPublishRetry(events, expectedVersion) then ZIO.unit
+          if alreadyPublished(events) then ZIO.unit
           else ZIO.fail(error)
         }
       case other => ZIO.fail(other)
@@ -97,8 +94,5 @@ final class ArticleCommandService(store: ArticleEventStore, clock: ServerClock):
   private def alreadyPublished(events: Chunk[SequencedArticleEvent]): Boolean =
     events.exists(_.event.isInstanceOf[ArticlePublished])
 
-  private def isIdempotentPublishRetry(events: Chunk[SequencedArticleEvent], expectedVersion: Long): Boolean =
-    publishedSeq(events).exists(seq => expectedVersion == seq - 1L)
-
-  private def publishedSeq(events: Chunk[SequencedArticleEvent]): Option[Long] =
-    events.collectFirst { case SequencedArticleEvent(seq, _: ArticlePublished) => seq }
+  private def hasSameInitialDraft(events: Chunk[SequencedArticleEvent], event: ArticleDrafted): Boolean =
+    events.minByOption(_.seq).exists(_.event == event)

--- a/apps/api/application/src/main/scala/morecat/application/ArticleCommandService.scala
+++ b/apps/api/application/src/main/scala/morecat/application/ArticleCommandService.scala
@@ -30,20 +30,26 @@ enum PublishResult:
 final class ArticleCommandService(store: ArticleEventStore, clock: ServerClock):
 
   def createDraft(command: CreateDraftCommand): IO[CommandError, Unit] =
-    for
-      slug <- ZIO.fromEither(Slug.either(command.slug)).mapError(_ => CommandError.InvalidSlug)
-      title <- ZIO.fromEither(Title.either(command.title)).mapError(_ => CommandError.InvalidTitle)
-      event = ArticleDrafted(slug, title, command.body)
-      events <- store.load(command.articleId).mapError(toCommandError)
-      _ <-
-        if events.isEmpty then
-          store
-            .createDraft(command.articleId, event)
-            .mapError(toCommandError)
-            .catchAll(recoverCreateDraftConflict(command.articleId, event))
-        else if hasSameInitialDraft(events, event) then ZIO.unit
-        else ZIO.fail(CommandError.VersionConflict)
-    yield ()
+    ZIO
+      .fromEither(Slug.either(command.slug))
+      .mapError(_ => CommandError.InvalidSlug)
+      .flatMap { slug =>
+        ZIO
+          .fromEither(Title.either(command.title))
+          .mapError(_ => CommandError.InvalidTitle)
+          .flatMap { title =>
+            val event = ArticleDrafted(slug, title, command.body)
+            store.load(command.articleId).mapError(toCommandError).flatMap { events =>
+              if events.isEmpty then
+                store
+                  .createDraft(command.articleId, event)
+                  .mapError(toCommandError)
+                  .catchAll(recoverCreateDraftConflict(command.articleId, event))
+              else if hasSameInitialDraft(events, event) then ZIO.unit
+              else ZIO.fail(CommandError.VersionConflict)
+            }
+          }
+      }
 
   def publish(command: PublishArticleCommand): IO[CommandError, PublishResult] =
     for

--- a/apps/api/application/src/main/scala/morecat/application/ArticleCommandService.scala
+++ b/apps/api/application/src/main/scala/morecat/application/ArticleCommandService.scala
@@ -56,11 +56,12 @@ final class ArticleCommandService(store: ArticleEventStore, clock: ServerClock):
         else
           for
             publishedAt <- clock.nowMillis
-            _ <- store
+            result <- store
               .append(command.articleId, command.expectedVersion, ArticlePublished(publishedAt))
+              .as(PublishResult.Published)
               .mapError(toCommandError)
               .catchAll(recoverPublishConflict(command.articleId))
-          yield PublishResult.Published
+          yield result
     yield result
 
   private def recoverCreateDraftConflict(
@@ -77,11 +78,11 @@ final class ArticleCommandService(store: ArticleEventStore, clock: ServerClock):
 
   private def recoverPublishConflict(
     articleId: ArticleId,
-  )(error: CommandError): IO[CommandError, Unit] =
+  )(error: CommandError): IO[CommandError, PublishResult] =
     error match
       case CommandError.VersionConflict =>
         store.load(articleId).mapError(toCommandError).flatMap { events =>
-          if alreadyPublished(events) then ZIO.unit
+          if alreadyPublished(events) then ZIO.succeed(PublishResult.AlreadyPublished)
           else ZIO.fail(error)
         }
       case other => ZIO.fail(other)

--- a/apps/api/application/src/main/scala/morecat/application/ArticleCommandService.scala
+++ b/apps/api/application/src/main/scala/morecat/application/ArticleCommandService.scala
@@ -21,7 +21,7 @@ enum CommandError:
   case SlugConflict
   case VersionConflict
   case ArticleNotFound
-  case StoreUnavailable(message: String)
+  case StoreUnavailable
 
 enum PublishResult:
   case Published
@@ -91,7 +91,7 @@ final class ArticleCommandService(store: ArticleEventStore, clock: ServerClock):
     error match
       case EventStoreError.SlugAlreadyReserved => CommandError.SlugConflict
       case EventStoreError.VersionConflict     => CommandError.VersionConflict
-      case EventStoreError.Unavailable(msg)    => CommandError.StoreUnavailable(msg)
+      case EventStoreError.Unavailable(_)      => CommandError.StoreUnavailable
 
   private def currentVersion(events: Chunk[SequencedArticleEvent]): Long =
     events.map(_.seq).maxOption.getOrElse(0L)

--- a/apps/api/application/src/main/scala/morecat/application/ArticleCommandService.scala
+++ b/apps/api/application/src/main/scala/morecat/application/ArticleCommandService.scala
@@ -34,7 +34,11 @@ final class ArticleCommandService(store: ArticleEventStore, clock: ServerClock):
       slug  <- ZIO.fromEither(Slug.either(command.slug)).mapError(_ => CommandError.InvalidSlug)
       title <- ZIO.fromEither(Title.either(command.title)).mapError(_ => CommandError.InvalidTitle)
       event = ArticleDrafted(slug, title, command.body)
-      _     <- store.createDraft(command.articleId, event).mapError(toCommandError)
+      events <- store.load(command.articleId).mapError(toCommandError)
+      _ <-
+        if events.isEmpty then store.createDraft(command.articleId, event).mapError(toCommandError)
+        else if events.length == 1 && events.headOption.exists(_.event == event) then ZIO.unit
+        else ZIO.fail(CommandError.VersionConflict)
     yield ()
 
   def publish(command: PublishArticleCommand): IO[CommandError, PublishResult] =
@@ -42,8 +46,10 @@ final class ArticleCommandService(store: ArticleEventStore, clock: ServerClock):
       events <- store.load(command.articleId).mapError(toCommandError)
       result <-
         if events.isEmpty then ZIO.fail(CommandError.ArticleNotFound)
+        else if alreadyPublished(events) && isIdempotentPublishRetry(events, command.expectedVersion) then
+          ZIO.succeed(PublishResult.AlreadyPublished)
         else if currentVersion(events) != command.expectedVersion then ZIO.fail(CommandError.VersionConflict)
-        else if events.exists(_.event.isInstanceOf[ArticlePublished]) then ZIO.succeed(PublishResult.AlreadyPublished)
+        else if alreadyPublished(events) then ZIO.succeed(PublishResult.AlreadyPublished)
         else
           for
             publishedAt <- clock.nowMillis
@@ -61,3 +67,12 @@ final class ArticleCommandService(store: ArticleEventStore, clock: ServerClock):
 
   private def currentVersion(events: Chunk[SequencedArticleEvent]): Long =
     events.map(_.seq).maxOption.getOrElse(0L)
+
+  private def alreadyPublished(events: Chunk[SequencedArticleEvent]): Boolean =
+    events.exists(_.event.isInstanceOf[ArticlePublished])
+
+  private def isIdempotentPublishRetry(events: Chunk[SequencedArticleEvent], expectedVersion: Long): Boolean =
+    publishedSeq(events).exists(seq => expectedVersion == seq - 1L)
+
+  private def publishedSeq(events: Chunk[SequencedArticleEvent]): Option[Long] =
+    events.collectFirst { case SequencedArticleEvent(seq, _: ArticlePublished) => seq }

--- a/apps/api/application/src/main/scala/morecat/application/ArticleCommandService.scala
+++ b/apps/api/application/src/main/scala/morecat/application/ArticleCommandService.scala
@@ -42,6 +42,7 @@ final class ArticleCommandService(store: ArticleEventStore, clock: ServerClock):
       events <- store.load(command.articleId).mapError(toCommandError)
       result <-
         if events.isEmpty then ZIO.fail(CommandError.ArticleNotFound)
+        else if currentVersion(events) != command.expectedVersion then ZIO.fail(CommandError.VersionConflict)
         else if events.exists(_.event.isInstanceOf[ArticlePublished]) then ZIO.succeed(PublishResult.AlreadyPublished)
         else
           for
@@ -57,3 +58,6 @@ final class ArticleCommandService(store: ArticleEventStore, clock: ServerClock):
       case EventStoreError.SlugAlreadyReserved => CommandError.SlugConflict
       case EventStoreError.VersionConflict    => CommandError.VersionConflict
       case EventStoreError.Unavailable(msg)   => CommandError.StoreUnavailable(msg)
+
+  private def currentVersion(events: Chunk[SequencedArticleEvent]): Long =
+    events.map(_.seq).maxOption.getOrElse(0L)

--- a/apps/api/application/src/main/scala/morecat/application/ArticleCommandService.scala
+++ b/apps/api/application/src/main/scala/morecat/application/ArticleCommandService.scala
@@ -1,0 +1,59 @@
+package morecat.application
+
+import morecat.domain.*
+import zio.*
+
+final case class CreateDraftCommand(
+    articleId: ArticleId,
+    slug: String,
+    title: String,
+    body: String,
+)
+
+final case class PublishArticleCommand(
+    articleId: ArticleId,
+    expectedVersion: Long,
+)
+
+enum CommandError:
+  case InvalidSlug
+  case InvalidTitle
+  case SlugConflict
+  case VersionConflict
+  case ArticleNotFound
+  case StoreUnavailable(message: String)
+
+enum PublishResult:
+  case Published
+  case AlreadyPublished
+
+final class ArticleCommandService(store: ArticleEventStore, clock: ServerClock):
+
+  def createDraft(command: CreateDraftCommand): IO[CommandError, Unit] =
+    for
+      slug  <- ZIO.fromEither(Slug.either(command.slug)).mapError(_ => CommandError.InvalidSlug)
+      title <- ZIO.fromEither(Title.either(command.title)).mapError(_ => CommandError.InvalidTitle)
+      event = ArticleDrafted(slug, title, command.body)
+      _     <- store.createDraft(command.articleId, event).mapError(toCommandError)
+    yield ()
+
+  def publish(command: PublishArticleCommand): IO[CommandError, PublishResult] =
+    for
+      events <- store.load(command.articleId).mapError(toCommandError)
+      result <-
+        if events.isEmpty then ZIO.fail(CommandError.ArticleNotFound)
+        else if events.exists(_.event.isInstanceOf[ArticlePublished]) then ZIO.succeed(PublishResult.AlreadyPublished)
+        else
+          for
+            publishedAt <- clock.nowMillis
+            _ <- store
+              .append(command.articleId, command.expectedVersion, ArticlePublished(publishedAt))
+              .mapError(toCommandError)
+          yield PublishResult.Published
+    yield result
+
+  private def toCommandError(error: EventStoreError): CommandError =
+    error match
+      case EventStoreError.SlugAlreadyReserved => CommandError.SlugConflict
+      case EventStoreError.VersionConflict    => CommandError.VersionConflict
+      case EventStoreError.Unavailable(msg)   => CommandError.StoreUnavailable(msg)

--- a/apps/api/application/src/main/scala/morecat/application/ArticleCommandService.scala
+++ b/apps/api/application/src/main/scala/morecat/application/ArticleCommandService.scala
@@ -31,11 +31,11 @@ final class ArticleCommandService(store: ArticleEventStore, clock: ServerClock):
 
   def createDraft(command: CreateDraftCommand): IO[CommandError, Unit] =
     for
-      slug  <- ZIO.fromEither(Slug.either(command.slug)).mapError(_ => CommandError.InvalidSlug)
+      slug <- ZIO.fromEither(Slug.either(command.slug)).mapError(_ => CommandError.InvalidSlug)
       title <- ZIO.fromEither(Title.either(command.title)).mapError(_ => CommandError.InvalidTitle)
       event = ArticleDrafted(slug, title, command.body)
       events <- store.load(command.articleId).mapError(toCommandError)
-      _      <-
+      _ <-
         if events.isEmpty then
           store
             .createDraft(command.articleId, event)
@@ -56,7 +56,7 @@ final class ArticleCommandService(store: ArticleEventStore, clock: ServerClock):
         else
           for
             publishedAt <- clock.nowMillis
-            _           <- store
+            _ <- store
               .append(command.articleId, command.expectedVersion, ArticlePublished(publishedAt))
               .mapError(toCommandError)
               .catchAll(recoverPublishConflict(command.articleId))

--- a/apps/api/application/src/main/scala/morecat/application/ArticleCommandService.scala
+++ b/apps/api/application/src/main/scala/morecat/application/ArticleCommandService.scala
@@ -37,6 +37,7 @@ final class ArticleCommandService(store: ArticleEventStore, clock: ServerClock):
       events <- store.load(command.articleId).mapError(toCommandError)
       _ <-
         if events.isEmpty then store.createDraft(command.articleId, event).mapError(toCommandError)
+          .catchAll(recoverCreateDraftConflict(command.articleId, event))
         else if events.length == 1 && events.headOption.exists(_.event == event) then ZIO.unit
         else ZIO.fail(CommandError.VersionConflict)
     yield ()
@@ -56,8 +57,33 @@ final class ArticleCommandService(store: ArticleEventStore, clock: ServerClock):
             _ <- store
               .append(command.articleId, command.expectedVersion, ArticlePublished(publishedAt))
               .mapError(toCommandError)
+              .catchAll(recoverPublishConflict(command.articleId, command.expectedVersion))
           yield PublishResult.Published
     yield result
+
+  private def recoverCreateDraftConflict(
+      articleId: ArticleId,
+      event: ArticleDrafted,
+  )(error: CommandError): IO[CommandError, Unit] =
+    error match
+      case CommandError.SlugConflict | CommandError.VersionConflict =>
+        store.load(articleId).mapError(toCommandError).flatMap { events =>
+          if events.length == 1 && events.headOption.exists(_.event == event) then ZIO.unit
+          else ZIO.fail(error)
+        }
+      case other => ZIO.fail(other)
+
+  private def recoverPublishConflict(
+      articleId: ArticleId,
+      expectedVersion: Long,
+  )(error: CommandError): IO[CommandError, Unit] =
+    error match
+      case CommandError.VersionConflict =>
+        store.load(articleId).mapError(toCommandError).flatMap { events =>
+          if alreadyPublished(events) && isIdempotentPublishRetry(events, expectedVersion) then ZIO.unit
+          else ZIO.fail(error)
+        }
+      case other => ZIO.fail(other)
 
   private def toCommandError(error: EventStoreError): CommandError =
     error match

--- a/apps/api/application/src/main/scala/morecat/application/ArticleCommandService.scala
+++ b/apps/api/application/src/main/scala/morecat/application/ArticleCommandService.scala
@@ -4,15 +4,15 @@ import morecat.domain.*
 import zio.*
 
 final case class CreateDraftCommand(
-    articleId: ArticleId,
-    slug: String,
-    title: String,
-    body: String,
+  articleId: ArticleId,
+  slug: String,
+  title: String,
+  body: String,
 )
 
 final case class PublishArticleCommand(
-    articleId: ArticleId,
-    expectedVersion: Long,
+  articleId: ArticleId,
+  expectedVersion: Long,
 )
 
 enum CommandError:
@@ -35,9 +35,12 @@ final class ArticleCommandService(store: ArticleEventStore, clock: ServerClock):
       title <- ZIO.fromEither(Title.either(command.title)).mapError(_ => CommandError.InvalidTitle)
       event = ArticleDrafted(slug, title, command.body)
       events <- store.load(command.articleId).mapError(toCommandError)
-      _ <-
-        if events.isEmpty then store.createDraft(command.articleId, event).mapError(toCommandError)
-          .catchAll(recoverCreateDraftConflict(command.articleId, event))
+      _      <-
+        if events.isEmpty then
+          store
+            .createDraft(command.articleId, event)
+            .mapError(toCommandError)
+            .catchAll(recoverCreateDraftConflict(command.articleId, event))
         else if hasSameInitialDraft(events, event) then ZIO.unit
         else ZIO.fail(CommandError.VersionConflict)
     yield ()
@@ -48,11 +51,12 @@ final class ArticleCommandService(store: ArticleEventStore, clock: ServerClock):
       result <-
         if events.isEmpty then ZIO.fail(CommandError.ArticleNotFound)
         else if alreadyPublished(events) then ZIO.succeed(PublishResult.AlreadyPublished)
-        else if currentVersion(events) != command.expectedVersion then ZIO.fail(CommandError.VersionConflict)
+        else if currentVersion(events) != command.expectedVersion then
+          ZIO.fail(CommandError.VersionConflict)
         else
           for
             publishedAt <- clock.nowMillis
-            _ <- store
+            _           <- store
               .append(command.articleId, command.expectedVersion, ArticlePublished(publishedAt))
               .mapError(toCommandError)
               .catchAll(recoverPublishConflict(command.articleId))
@@ -60,8 +64,8 @@ final class ArticleCommandService(store: ArticleEventStore, clock: ServerClock):
     yield result
 
   private def recoverCreateDraftConflict(
-      articleId: ArticleId,
-      event: ArticleDrafted,
+    articleId: ArticleId,
+    event: ArticleDrafted,
   )(error: CommandError): IO[CommandError, Unit] =
     error match
       case CommandError.SlugConflict | CommandError.VersionConflict =>
@@ -72,7 +76,7 @@ final class ArticleCommandService(store: ArticleEventStore, clock: ServerClock):
       case other => ZIO.fail(other)
 
   private def recoverPublishConflict(
-      articleId: ArticleId,
+    articleId: ArticleId,
   )(error: CommandError): IO[CommandError, Unit] =
     error match
       case CommandError.VersionConflict =>
@@ -85,8 +89,8 @@ final class ArticleCommandService(store: ArticleEventStore, clock: ServerClock):
   private def toCommandError(error: EventStoreError): CommandError =
     error match
       case EventStoreError.SlugAlreadyReserved => CommandError.SlugConflict
-      case EventStoreError.VersionConflict    => CommandError.VersionConflict
-      case EventStoreError.Unavailable(msg)   => CommandError.StoreUnavailable(msg)
+      case EventStoreError.VersionConflict     => CommandError.VersionConflict
+      case EventStoreError.Unavailable(msg)    => CommandError.StoreUnavailable(msg)
 
   private def currentVersion(events: Chunk[SequencedArticleEvent]): Long =
     events.map(_.seq).maxOption.getOrElse(0L)
@@ -94,5 +98,8 @@ final class ArticleCommandService(store: ArticleEventStore, clock: ServerClock):
   private def alreadyPublished(events: Chunk[SequencedArticleEvent]): Boolean =
     events.exists(_.event.isInstanceOf[ArticlePublished])
 
-  private def hasSameInitialDraft(events: Chunk[SequencedArticleEvent], event: ArticleDrafted): Boolean =
+  private def hasSameInitialDraft(
+    events: Chunk[SequencedArticleEvent],
+    event: ArticleDrafted
+  ): Boolean =
     events.minByOption(_.seq).exists(_.event == event)

--- a/apps/api/application/src/main/scala/morecat/application/ArticlePorts.scala
+++ b/apps/api/application/src/main/scala/morecat/application/ArticlePorts.scala
@@ -1,0 +1,33 @@
+package morecat.application
+
+import morecat.domain.*
+import zio.*
+
+final case class SequencedArticleEvent(seq: Long, event: ArticleEvent)
+
+enum EventStoreError:
+  case SlugAlreadyReserved
+  case VersionConflict
+  case Unavailable(message: String)
+
+trait ArticleEventStore:
+  def createDraft(articleId: ArticleId, event: ArticleDrafted): IO[EventStoreError, Unit]
+  def load(articleId: ArticleId): IO[EventStoreError, Chunk[SequencedArticleEvent]]
+  def append(articleId: ArticleId, expectedVersion: Long, event: ArticleEvent): IO[EventStoreError, Unit]
+
+trait ServerClock:
+  def nowMillis: UIO[Long]
+
+final case class PublishedArticle(
+    id: ArticleId,
+    slug: Slug,
+    title: Title,
+    body: String,
+    publishedAt: Long,
+)
+
+trait PublishedArticleQuery:
+  def findBySlug(slug: Slug): IO[QueryError, Option[PublishedArticle]]
+
+enum QueryError:
+  case Unavailable(message: String)

--- a/apps/api/application/src/main/scala/morecat/application/ArticlePorts.scala
+++ b/apps/api/application/src/main/scala/morecat/application/ArticlePorts.scala
@@ -13,17 +13,21 @@ enum EventStoreError:
 trait ArticleEventStore:
   def createDraft(articleId: ArticleId, event: ArticleDrafted): IO[EventStoreError, Unit]
   def load(articleId: ArticleId): IO[EventStoreError, Chunk[SequencedArticleEvent]]
-  def append(articleId: ArticleId, expectedVersion: Long, event: ArticleEvent): IO[EventStoreError, Unit]
+  def append(
+    articleId: ArticleId,
+    expectedVersion: Long,
+    event: ArticleEvent
+  ): IO[EventStoreError, Unit]
 
 trait ServerClock:
   def nowMillis: UIO[Long]
 
 final case class PublishedArticle(
-    id: ArticleId,
-    slug: Slug,
-    title: Title,
-    body: String,
-    publishedAt: Long,
+  id: ArticleId,
+  slug: Slug,
+  title: Title,
+  body: String,
+  publishedAt: Long,
 )
 
 trait PublishedArticleQuery:

--- a/apps/api/application/src/main/scala/morecat/application/PublishedArticleService.scala
+++ b/apps/api/application/src/main/scala/morecat/application/PublishedArticleService.scala
@@ -1,0 +1,22 @@
+package morecat.application
+
+import morecat.domain.*
+import zio.*
+
+enum PublishedArticleError:
+  case InvalidSlug
+  case NotFound
+  case QueryUnavailable(message: String)
+
+final class PublishedArticleService(query: PublishedArticleQuery):
+
+  def getBySlug(rawSlug: String): IO[PublishedArticleError, PublishedArticle] =
+    for
+      slug    <- ZIO.fromEither(Slug.either(rawSlug)).mapError(_ => PublishedArticleError.InvalidSlug)
+      article <- query.findBySlug(slug).mapError(toPublishedArticleError)
+      result  <- ZIO.fromOption(article).orElseFail(PublishedArticleError.NotFound)
+    yield result
+
+  private def toPublishedArticleError(error: QueryError): PublishedArticleError =
+    error match
+      case QueryError.Unavailable(message) => PublishedArticleError.QueryUnavailable(message)

--- a/apps/api/application/src/main/scala/morecat/application/PublishedArticleService.scala
+++ b/apps/api/application/src/main/scala/morecat/application/PublishedArticleService.scala
@@ -6,7 +6,7 @@ import zio.*
 enum PublishedArticleError:
   case InvalidSlug
   case NotFound
-  case QueryUnavailable(message: String)
+  case QueryUnavailable
 
 final class PublishedArticleService(query: PublishedArticleQuery):
 
@@ -19,4 +19,4 @@ final class PublishedArticleService(query: PublishedArticleQuery):
 
   private def toPublishedArticleError(error: QueryError): PublishedArticleError =
     error match
-      case QueryError.Unavailable(message) => PublishedArticleError.QueryUnavailable(message)
+      case QueryError.Unavailable(_) => PublishedArticleError.QueryUnavailable

--- a/apps/api/application/src/main/scala/morecat/application/PublishedArticleService.scala
+++ b/apps/api/application/src/main/scala/morecat/application/PublishedArticleService.scala
@@ -14,7 +14,7 @@ final class PublishedArticleService(query: PublishedArticleQuery):
     for
       slug <- ZIO.fromEither(Slug.either(rawSlug)).mapError(_ => PublishedArticleError.InvalidSlug)
       article <- query.findBySlug(slug).mapError(toPublishedArticleError)
-      result  <- ZIO.fromOption(article).orElseFail(PublishedArticleError.NotFound)
+      result <- ZIO.fromOption(article).orElseFail(PublishedArticleError.NotFound)
     yield result
 
   private def toPublishedArticleError(error: QueryError): PublishedArticleError =

--- a/apps/api/application/src/main/scala/morecat/application/PublishedArticleService.scala
+++ b/apps/api/application/src/main/scala/morecat/application/PublishedArticleService.scala
@@ -12,7 +12,7 @@ final class PublishedArticleService(query: PublishedArticleQuery):
 
   def getBySlug(rawSlug: String): IO[PublishedArticleError, PublishedArticle] =
     for
-      slug    <- ZIO.fromEither(Slug.either(rawSlug)).mapError(_ => PublishedArticleError.InvalidSlug)
+      slug <- ZIO.fromEither(Slug.either(rawSlug)).mapError(_ => PublishedArticleError.InvalidSlug)
       article <- query.findBySlug(slug).mapError(toPublishedArticleError)
       result  <- ZIO.fromOption(article).orElseFail(PublishedArticleError.NotFound)
     yield result

--- a/apps/api/application/src/test/scala/morecat/application/ArticleCommandServiceSpec.scala
+++ b/apps/api/application/src/test/scala/morecat/application/ArticleCommandServiceSpec.scala
@@ -60,6 +60,24 @@ object ArticleCommandServiceSpec extends ZIOSpecDefault:
           exit <- service.createDraft(CreateDraftCommand(articleId, "../bad", "Hello", "body")).exit
         yield assertTrue(exit == Exit.fail(CommandError.InvalidSlug), store.created.isEmpty)
       },
+      test("is idempotent for the same articleId and same draft content") {
+        val drafted = ArticleDrafted(Slug.applyUnsafe("hello-world"), Title.applyUnsafe("Hello"), "body")
+        val store   = RecordingStore(initialEvents = Chunk(SequencedArticleEvent(seq = 1L, event = drafted)))
+        val service = ArticleCommandService(store, FixedClock(123L))
+
+        for
+          _ <- service.createDraft(CreateDraftCommand(articleId, "hello-world", "Hello", "body"))
+        yield assertTrue(store.created.isEmpty)
+      },
+      test("rejects the same articleId with different draft content") {
+        val drafted = ArticleDrafted(Slug.applyUnsafe("hello-world"), Title.applyUnsafe("Hello"), "body")
+        val store   = RecordingStore(initialEvents = Chunk(SequencedArticleEvent(seq = 1L, event = drafted)))
+        val service = ArticleCommandService(store, FixedClock(123L))
+
+        assertZIO(service.createDraft(CreateDraftCommand(articleId, "hello-world", "Changed", "body")).exit)(
+          fails(equalTo(CommandError.VersionConflict)),
+        )
+      },
     ),
     suite("publish")(
       test("fails with ArticleNotFound when the stream does not exist") {
@@ -112,7 +130,7 @@ object ArticleCommandServiceSpec extends ZIOSpecDefault:
           result <- service.publish(PublishArticleCommand(articleId, expectedVersion = 2L))
         yield assertTrue(result == PublishResult.AlreadyPublished, store.appended.isEmpty)
       },
-      test("does not hide expected version conflicts when the article is already published") {
+      test("is idempotent when retrying the original publish command after success") {
         val events = Chunk(
           SequencedArticleEvent(1L, ArticleDrafted(Slug.applyUnsafe("hello-world"), Title.applyUnsafe("Hello"), "body")),
           SequencedArticleEvent(2L, ArticlePublished(publishedAt = 999L)),
@@ -121,7 +139,19 @@ object ArticleCommandServiceSpec extends ZIOSpecDefault:
         val service = ArticleCommandService(store, FixedClock(1234L))
 
         for
-          exit <- service.publish(PublishArticleCommand(articleId, expectedVersion = 1L)).exit
+          result <- service.publish(PublishArticleCommand(articleId, expectedVersion = 1L))
+        yield assertTrue(result == PublishResult.AlreadyPublished, store.appended.isEmpty)
+      },
+      test("does not hide unrelated expected version conflicts when the article is already published") {
+        val events = Chunk(
+          SequencedArticleEvent(1L, ArticleDrafted(Slug.applyUnsafe("hello-world"), Title.applyUnsafe("Hello"), "body")),
+          SequencedArticleEvent(2L, ArticlePublished(publishedAt = 999L)),
+        )
+        val store   = RecordingStore(initialEvents = events)
+        val service = ArticleCommandService(store, FixedClock(1234L))
+
+        for
+          exit <- service.publish(PublishArticleCommand(articleId, expectedVersion = 0L)).exit
         yield assertTrue(exit == Exit.fail(CommandError.VersionConflict), store.appended.isEmpty)
       },
     ),

--- a/apps/api/application/src/test/scala/morecat/application/ArticleCommandServiceSpec.scala
+++ b/apps/api/application/src/test/scala/morecat/application/ArticleCommandServiceSpec.scala
@@ -11,17 +11,24 @@ object ArticleCommandServiceSpec extends ZIOSpecDefault:
 
   private final class RecordingStore(
       initialEvents: Chunk[SequencedArticleEvent] = Chunk.empty,
+      loadResults: List[IO[EventStoreError, Chunk[SequencedArticleEvent]]] = Nil,
       createDraftResult: IO[EventStoreError, Unit] = ZIO.unit,
       appendResult: IO[EventStoreError, Unit] = ZIO.unit,
   ) extends ArticleEventStore:
     var created: List[(ArticleId, ArticleDrafted)]            = Nil
     var appended: List[(ArticleId, Long, ArticleEvent)]       = Nil
+    private var remainingLoads = loadResults
     def createDraft(articleId: ArticleId, event: ArticleDrafted): IO[EventStoreError, Unit] =
       createDraftResult *> ZIO.succeed {
         created = created :+ (articleId, event)
       }
     def load(articleId: ArticleId): IO[EventStoreError, Chunk[SequencedArticleEvent]] =
-      ZIO.succeed(initialEvents)
+      remainingLoads match
+        case next :: rest =>
+          remainingLoads = rest
+          next
+        case Nil =>
+          ZIO.succeed(initialEvents)
     def append(articleId: ArticleId, expectedVersion: Long, event: ArticleEvent): IO[EventStoreError, Unit] =
       appendResult *> ZIO.succeed {
         appended = appended :+ (articleId, expectedVersion, event)
@@ -52,6 +59,14 @@ object ArticleCommandServiceSpec extends ZIOSpecDefault:
           fails(equalTo(CommandError.SlugConflict)),
         )
       },
+      test("maps store unavailability while loading to StoreUnavailable") {
+        val store = RecordingStore(loadResults = List(ZIO.fail(EventStoreError.Unavailable("down"))))
+        val service = ArticleCommandService(store, FixedClock(123L))
+
+        assertZIO(service.createDraft(CreateDraftCommand(articleId, "hello-world", "Hello", "body")).exit)(
+          fails(equalTo(CommandError.StoreUnavailable("down"))),
+        )
+      },
       test("rejects invalid slug before touching the store") {
         val store   = RecordingStore()
         val service = ArticleCommandService(store, FixedClock(123L))
@@ -77,6 +92,21 @@ object ArticleCommandServiceSpec extends ZIOSpecDefault:
         assertZIO(service.createDraft(CreateDraftCommand(articleId, "hello-world", "Changed", "body")).exit)(
           fails(equalTo(CommandError.VersionConflict)),
         )
+      },
+      test("treats create conflict as idempotent when reload shows the same draft") {
+        val drafted = ArticleDrafted(Slug.applyUnsafe("hello-world"), Title.applyUnsafe("Hello"), "body")
+        val store = RecordingStore(
+          loadResults = List(
+            ZIO.succeed(Chunk.empty),
+            ZIO.succeed(Chunk(SequencedArticleEvent(seq = 1L, event = drafted))),
+          ),
+          createDraftResult = ZIO.fail(EventStoreError.VersionConflict),
+        )
+        val service = ArticleCommandService(store, FixedClock(123L))
+
+        for
+          _ <- service.createDraft(CreateDraftCommand(articleId, "hello-world", "Hello", "body"))
+        yield assertTrue(store.created.isEmpty)
       },
     ),
     suite("publish")(
@@ -118,6 +148,14 @@ object ArticleCommandServiceSpec extends ZIOSpecDefault:
           fails(equalTo(CommandError.VersionConflict)),
         )
       },
+      test("maps store unavailability while loading to StoreUnavailable") {
+        val store = RecordingStore(loadResults = List(ZIO.fail(EventStoreError.Unavailable("down"))))
+        val service = ArticleCommandService(store, FixedClock(999L))
+
+        assertZIO(service.publish(PublishArticleCommand(articleId, expectedVersion = 1L)).exit)(
+          fails(equalTo(CommandError.StoreUnavailable("down"))),
+        )
+      },
       test("is idempotent when the article is already published") {
         val events = Chunk(
           SequencedArticleEvent(1L, ArticleDrafted(Slug.applyUnsafe("hello-world"), Title.applyUnsafe("Hello"), "body")),
@@ -153,6 +191,25 @@ object ArticleCommandServiceSpec extends ZIOSpecDefault:
         for
           exit <- service.publish(PublishArticleCommand(articleId, expectedVersion = 0L)).exit
         yield assertTrue(exit == Exit.fail(CommandError.VersionConflict), store.appended.isEmpty)
+      },
+      test("treats append conflict as idempotent when reload shows the publish succeeded") {
+        val drafted = SequencedArticleEvent(
+          seq = 1L,
+          event = ArticleDrafted(Slug.applyUnsafe("hello-world"), Title.applyUnsafe("Hello"), "body"),
+        )
+        val published = SequencedArticleEvent(seq = 2L, event = ArticlePublished(publishedAt = 999L))
+        val store = RecordingStore(
+          loadResults = List(
+            ZIO.succeed(Chunk(drafted)),
+            ZIO.succeed(Chunk(drafted, published)),
+          ),
+          appendResult = ZIO.fail(EventStoreError.VersionConflict),
+        )
+        val service = ArticleCommandService(store, FixedClock(999L))
+
+        assertZIO(service.publish(PublishArticleCommand(articleId, expectedVersion = 1L)))(
+          equalTo(PublishResult.Published),
+        )
       },
     ),
   )

--- a/apps/api/application/src/test/scala/morecat/application/ArticleCommandServiceSpec.scala
+++ b/apps/api/application/src/test/scala/morecat/application/ArticleCommandServiceSpec.scala
@@ -1,0 +1,116 @@
+package morecat.application
+
+import morecat.domain.*
+import zio.*
+import zio.test.Assertion.*
+import zio.test.*
+
+object ArticleCommandServiceSpec extends ZIOSpecDefault:
+
+  private val articleId = ArticleId.fromString("018f4edc-1f5a-7c4b-aef9-000000000001")
+
+  private final class RecordingStore(
+      initialEvents: Chunk[SequencedArticleEvent] = Chunk.empty,
+      createDraftResult: IO[EventStoreError, Unit] = ZIO.unit,
+      appendResult: IO[EventStoreError, Unit] = ZIO.unit,
+  ) extends ArticleEventStore:
+    var created: List[(ArticleId, ArticleDrafted)]            = Nil
+    var appended: List[(ArticleId, Long, ArticleEvent)]       = Nil
+    def createDraft(articleId: ArticleId, event: ArticleDrafted): IO[EventStoreError, Unit] =
+      createDraftResult *> ZIO.succeed {
+        created = created :+ (articleId, event)
+      }
+    def load(articleId: ArticleId): IO[EventStoreError, Chunk[SequencedArticleEvent]] =
+      ZIO.succeed(initialEvents)
+    def append(articleId: ArticleId, expectedVersion: Long, event: ArticleEvent): IO[EventStoreError, Unit] =
+      appendResult *> ZIO.succeed {
+        appended = appended :+ (articleId, expectedVersion, event)
+      }
+
+  private final class FixedClock(value: Long) extends ServerClock:
+    def nowMillis: UIO[Long] = ZIO.succeed(value)
+
+  def spec = suite("ArticleCommandService")(
+    suite("createDraft")(
+      test("creates an ArticleDrafted event with validated slug and title") {
+        val store   = RecordingStore()
+        val service = ArticleCommandService(store, FixedClock(123L))
+
+        for
+          _ <- service.createDraft(CreateDraftCommand(articleId, "hello-world", "Hello", "body"))
+        yield assertTrue(
+          store.created == List(
+            (articleId, ArticleDrafted(Slug.applyUnsafe("hello-world"), Title.applyUnsafe("Hello"), "body")),
+          ),
+        )
+      },
+      test("maps slug reservation conflicts to SlugConflict") {
+        val store   = RecordingStore(createDraftResult = ZIO.fail(EventStoreError.SlugAlreadyReserved))
+        val service = ArticleCommandService(store, FixedClock(123L))
+
+        assertZIO(service.createDraft(CreateDraftCommand(articleId, "hello-world", "Hello", "body")).exit)(
+          fails(equalTo(CommandError.SlugConflict)),
+        )
+      },
+      test("rejects invalid slug before touching the store") {
+        val store   = RecordingStore()
+        val service = ArticleCommandService(store, FixedClock(123L))
+
+        for
+          exit <- service.createDraft(CreateDraftCommand(articleId, "../bad", "Hello", "body")).exit
+        yield assertTrue(exit == Exit.fail(CommandError.InvalidSlug), store.created.isEmpty)
+      },
+    ),
+    suite("publish")(
+      test("fails with ArticleNotFound when the stream does not exist") {
+        val store   = RecordingStore()
+        val service = ArticleCommandService(store, FixedClock(123L))
+
+        assertZIO(service.publish(PublishArticleCommand(articleId, expectedVersion = 1L)).exit)(
+          fails(equalTo(CommandError.ArticleNotFound)),
+        )
+      },
+      test("appends ArticlePublished with server time and expected version") {
+        val drafted = SequencedArticleEvent(
+          seq = 1L,
+          event = ArticleDrafted(Slug.applyUnsafe("hello-world"), Title.applyUnsafe("Hello"), "body"),
+        )
+        val store   = RecordingStore(initialEvents = Chunk(drafted))
+        val service = ArticleCommandService(store, FixedClock(999L))
+
+        for
+          result <- service.publish(PublishArticleCommand(articleId, expectedVersion = 1L))
+        yield assertTrue(
+          result == PublishResult.Published,
+          store.appended == List((articleId, 1L, ArticlePublished(publishedAt = 999L))),
+        )
+      },
+      test("maps expected version conflicts without hiding them") {
+        val drafted = SequencedArticleEvent(
+          seq = 1L,
+          event = ArticleDrafted(Slug.applyUnsafe("hello-world"), Title.applyUnsafe("Hello"), "body"),
+        )
+        val store = RecordingStore(
+          initialEvents = Chunk(drafted),
+          appendResult = ZIO.fail(EventStoreError.VersionConflict),
+        )
+        val service = ArticleCommandService(store, FixedClock(999L))
+
+        assertZIO(service.publish(PublishArticleCommand(articleId, expectedVersion = 0L)).exit)(
+          fails(equalTo(CommandError.VersionConflict)),
+        )
+      },
+      test("is idempotent when the article is already published") {
+        val events = Chunk(
+          SequencedArticleEvent(1L, ArticleDrafted(Slug.applyUnsafe("hello-world"), Title.applyUnsafe("Hello"), "body")),
+          SequencedArticleEvent(2L, ArticlePublished(publishedAt = 999L)),
+        )
+        val store   = RecordingStore(initialEvents = events)
+        val service = ArticleCommandService(store, FixedClock(1234L))
+
+        for
+          result <- service.publish(PublishArticleCommand(articleId, expectedVersion = 2L))
+        yield assertTrue(result == PublishResult.AlreadyPublished, store.appended.isEmpty)
+      },
+    ),
+  )

--- a/apps/api/application/src/test/scala/morecat/application/ArticleCommandServiceSpec.scala
+++ b/apps/api/application/src/test/scala/morecat/application/ArticleCommandServiceSpec.scala
@@ -10,14 +10,14 @@ object ArticleCommandServiceSpec extends ZIOSpecDefault:
   private val articleId = ArticleId.fromString("018f4edc-1f5a-7c4b-aef9-000000000001")
 
   private final class RecordingStore(
-      initialEvents: Chunk[SequencedArticleEvent] = Chunk.empty,
-      loadResults: List[IO[EventStoreError, Chunk[SequencedArticleEvent]]] = Nil,
-      createDraftResult: IO[EventStoreError, Unit] = ZIO.unit,
-      appendResult: IO[EventStoreError, Unit] = ZIO.unit,
+    initialEvents: Chunk[SequencedArticleEvent] = Chunk.empty,
+    loadResults: List[IO[EventStoreError, Chunk[SequencedArticleEvent]]] = Nil,
+    createDraftResult: IO[EventStoreError, Unit] = ZIO.unit,
+    appendResult: IO[EventStoreError, Unit] = ZIO.unit,
   ) extends ArticleEventStore:
-    var created: List[(ArticleId, ArticleDrafted)]            = Nil
-    var appended: List[(ArticleId, Long, ArticleEvent)]       = Nil
-    private var remainingLoads = loadResults
+    var created: List[(ArticleId, ArticleDrafted)]      = Nil
+    var appended: List[(ArticleId, Long, ArticleEvent)] = Nil
+    private var remainingLoads                          = loadResults
     def createDraft(articleId: ArticleId, event: ArticleDrafted): IO[EventStoreError, Unit] =
       createDraftResult *> ZIO.succeed {
         created = created :+ (articleId, event)
@@ -29,7 +29,11 @@ object ArticleCommandServiceSpec extends ZIOSpecDefault:
           next
         case Nil =>
           ZIO.succeed(initialEvents)
-    def append(articleId: ArticleId, expectedVersion: Long, event: ArticleEvent): IO[EventStoreError, Unit] =
+    def append(
+      articleId: ArticleId,
+      expectedVersion: Long,
+      event: ArticleEvent
+    ): IO[EventStoreError, Unit] =
       appendResult *> ZIO.succeed {
         appended = appended :+ (articleId, expectedVersion, event)
       }
@@ -43,27 +47,35 @@ object ArticleCommandServiceSpec extends ZIOSpecDefault:
         val store   = RecordingStore()
         val service = ArticleCommandService(store, FixedClock(123L))
 
-        for
-          _ <- service.createDraft(CreateDraftCommand(articleId, "hello-world", "Hello", "body"))
+        for _ <- service.createDraft(CreateDraftCommand(articleId, "hello-world", "Hello", "body"))
         yield assertTrue(
           store.created == List(
-            (articleId, ArticleDrafted(Slug.applyUnsafe("hello-world"), Title.applyUnsafe("Hello"), "body")),
+            (
+              articleId,
+              ArticleDrafted(Slug.applyUnsafe("hello-world"), Title.applyUnsafe("Hello"), "body")
+            ),
           ),
         )
       },
       test("maps slug reservation conflicts to SlugConflict") {
-        val store   = RecordingStore(createDraftResult = ZIO.fail(EventStoreError.SlugAlreadyReserved))
+        val store =
+          RecordingStore(createDraftResult = ZIO.fail(EventStoreError.SlugAlreadyReserved))
         val service = ArticleCommandService(store, FixedClock(123L))
 
-        assertZIO(service.createDraft(CreateDraftCommand(articleId, "hello-world", "Hello", "body")).exit)(
+        assertZIO(
+          service.createDraft(CreateDraftCommand(articleId, "hello-world", "Hello", "body")).exit
+        )(
           fails(equalTo(CommandError.SlugConflict)),
         )
       },
       test("maps store unavailability while loading to StoreUnavailable") {
-        val store = RecordingStore(loadResults = List(ZIO.fail(EventStoreError.Unavailable("down"))))
+        val store =
+          RecordingStore(loadResults = List(ZIO.fail(EventStoreError.Unavailable("down"))))
         val service = ArticleCommandService(store, FixedClock(123L))
 
-        assertZIO(service.createDraft(CreateDraftCommand(articleId, "hello-world", "Hello", "body")).exit)(
+        assertZIO(
+          service.createDraft(CreateDraftCommand(articleId, "hello-world", "Hello", "body")).exit
+        )(
           fails(equalTo(CommandError.StoreUnavailable("down"))),
         )
       },
@@ -71,21 +83,24 @@ object ArticleCommandServiceSpec extends ZIOSpecDefault:
         val store   = RecordingStore()
         val service = ArticleCommandService(store, FixedClock(123L))
 
-        for
-          exit <- service.createDraft(CreateDraftCommand(articleId, "../bad", "Hello", "body")).exit
+        for exit <- service
+            .createDraft(CreateDraftCommand(articleId, "../bad", "Hello", "body"))
+            .exit
         yield assertTrue(exit == Exit.fail(CommandError.InvalidSlug), store.created.isEmpty)
       },
       test("is idempotent for the same articleId and same draft content") {
-        val drafted = ArticleDrafted(Slug.applyUnsafe("hello-world"), Title.applyUnsafe("Hello"), "body")
-        val store   = RecordingStore(initialEvents = Chunk(SequencedArticleEvent(seq = 1L, event = drafted)))
+        val drafted =
+          ArticleDrafted(Slug.applyUnsafe("hello-world"), Title.applyUnsafe("Hello"), "body")
+        val store =
+          RecordingStore(initialEvents = Chunk(SequencedArticleEvent(seq = 1L, event = drafted)))
         val service = ArticleCommandService(store, FixedClock(123L))
 
-        for
-          _ <- service.createDraft(CreateDraftCommand(articleId, "hello-world", "Hello", "body"))
+        for _ <- service.createDraft(CreateDraftCommand(articleId, "hello-world", "Hello", "body"))
         yield assertTrue(store.created.isEmpty)
       },
       test("is idempotent for the same initial draft even after later events") {
-        val drafted = ArticleDrafted(Slug.applyUnsafe("hello-world"), Title.applyUnsafe("Hello"), "body")
+        val drafted =
+          ArticleDrafted(Slug.applyUnsafe("hello-world"), Title.applyUnsafe("Hello"), "body")
         val store = RecordingStore(
           initialEvents = Chunk(
             SequencedArticleEvent(seq = 1L, event = drafted),
@@ -94,21 +109,25 @@ object ArticleCommandServiceSpec extends ZIOSpecDefault:
         )
         val service = ArticleCommandService(store, FixedClock(123L))
 
-        for
-          _ <- service.createDraft(CreateDraftCommand(articleId, "hello-world", "Hello", "body"))
+        for _ <- service.createDraft(CreateDraftCommand(articleId, "hello-world", "Hello", "body"))
         yield assertTrue(store.created.isEmpty)
       },
       test("rejects the same articleId with different draft content") {
-        val drafted = ArticleDrafted(Slug.applyUnsafe("hello-world"), Title.applyUnsafe("Hello"), "body")
-        val store   = RecordingStore(initialEvents = Chunk(SequencedArticleEvent(seq = 1L, event = drafted)))
+        val drafted =
+          ArticleDrafted(Slug.applyUnsafe("hello-world"), Title.applyUnsafe("Hello"), "body")
+        val store =
+          RecordingStore(initialEvents = Chunk(SequencedArticleEvent(seq = 1L, event = drafted)))
         val service = ArticleCommandService(store, FixedClock(123L))
 
-        assertZIO(service.createDraft(CreateDraftCommand(articleId, "hello-world", "Changed", "body")).exit)(
+        assertZIO(
+          service.createDraft(CreateDraftCommand(articleId, "hello-world", "Changed", "body")).exit
+        )(
           fails(equalTo(CommandError.VersionConflict)),
         )
       },
       test("treats create conflict as idempotent when reload shows the same draft") {
-        val drafted = ArticleDrafted(Slug.applyUnsafe("hello-world"), Title.applyUnsafe("Hello"), "body")
+        val drafted =
+          ArticleDrafted(Slug.applyUnsafe("hello-world"), Title.applyUnsafe("Hello"), "body")
         val store = RecordingStore(
           loadResults = List(
             ZIO.succeed(Chunk.empty),
@@ -118,8 +137,7 @@ object ArticleCommandServiceSpec extends ZIOSpecDefault:
         )
         val service = ArticleCommandService(store, FixedClock(123L))
 
-        for
-          _ <- service.createDraft(CreateDraftCommand(articleId, "hello-world", "Hello", "body"))
+        for _ <- service.createDraft(CreateDraftCommand(articleId, "hello-world", "Hello", "body"))
         yield assertTrue(store.created.isEmpty)
       },
     ),
@@ -135,13 +153,13 @@ object ArticleCommandServiceSpec extends ZIOSpecDefault:
       test("appends ArticlePublished with server time and expected version") {
         val drafted = SequencedArticleEvent(
           seq = 1L,
-          event = ArticleDrafted(Slug.applyUnsafe("hello-world"), Title.applyUnsafe("Hello"), "body"),
+          event =
+            ArticleDrafted(Slug.applyUnsafe("hello-world"), Title.applyUnsafe("Hello"), "body"),
         )
         val store   = RecordingStore(initialEvents = Chunk(drafted))
         val service = ArticleCommandService(store, FixedClock(999L))
 
-        for
-          result <- service.publish(PublishArticleCommand(articleId, expectedVersion = 1L))
+        for result <- service.publish(PublishArticleCommand(articleId, expectedVersion = 1L))
         yield assertTrue(
           result == PublishResult.Published,
           store.appended == List((articleId, 1L, ArticlePublished(publishedAt = 999L))),
@@ -150,7 +168,8 @@ object ArticleCommandServiceSpec extends ZIOSpecDefault:
       test("maps expected version conflicts without hiding them") {
         val drafted = SequencedArticleEvent(
           seq = 1L,
-          event = ArticleDrafted(Slug.applyUnsafe("hello-world"), Title.applyUnsafe("Hello"), "body"),
+          event =
+            ArticleDrafted(Slug.applyUnsafe("hello-world"), Title.applyUnsafe("Hello"), "body"),
         )
         val store = RecordingStore(
           initialEvents = Chunk(drafted),
@@ -163,7 +182,8 @@ object ArticleCommandServiceSpec extends ZIOSpecDefault:
         )
       },
       test("maps store unavailability while loading to StoreUnavailable") {
-        val store = RecordingStore(loadResults = List(ZIO.fail(EventStoreError.Unavailable("down"))))
+        val store =
+          RecordingStore(loadResults = List(ZIO.fail(EventStoreError.Unavailable("down"))))
         val service = ArticleCommandService(store, FixedClock(999L))
 
         assertZIO(service.publish(PublishArticleCommand(articleId, expectedVersion = 1L)).exit)(
@@ -172,46 +192,56 @@ object ArticleCommandServiceSpec extends ZIOSpecDefault:
       },
       test("is idempotent when the article is already published") {
         val events = Chunk(
-          SequencedArticleEvent(1L, ArticleDrafted(Slug.applyUnsafe("hello-world"), Title.applyUnsafe("Hello"), "body")),
+          SequencedArticleEvent(
+            1L,
+            ArticleDrafted(Slug.applyUnsafe("hello-world"), Title.applyUnsafe("Hello"), "body")
+          ),
           SequencedArticleEvent(2L, ArticlePublished(publishedAt = 999L)),
         )
         val store   = RecordingStore(initialEvents = events)
         val service = ArticleCommandService(store, FixedClock(1234L))
 
-        for
-          result <- service.publish(PublishArticleCommand(articleId, expectedVersion = 2L))
+        for result <- service.publish(PublishArticleCommand(articleId, expectedVersion = 2L))
         yield assertTrue(result == PublishResult.AlreadyPublished, store.appended.isEmpty)
       },
       test("is idempotent when retrying the original publish command after success") {
         val events = Chunk(
-          SequencedArticleEvent(1L, ArticleDrafted(Slug.applyUnsafe("hello-world"), Title.applyUnsafe("Hello"), "body")),
+          SequencedArticleEvent(
+            1L,
+            ArticleDrafted(Slug.applyUnsafe("hello-world"), Title.applyUnsafe("Hello"), "body")
+          ),
           SequencedArticleEvent(2L, ArticlePublished(publishedAt = 999L)),
         )
         val store   = RecordingStore(initialEvents = events)
         val service = ArticleCommandService(store, FixedClock(1234L))
 
-        for
-          result <- service.publish(PublishArticleCommand(articleId, expectedVersion = 1L))
+        for result <- service.publish(PublishArticleCommand(articleId, expectedVersion = 1L))
         yield assertTrue(result == PublishResult.AlreadyPublished, store.appended.isEmpty)
       },
-      test("is idempotent for publish once the article is already published regardless of stale version") {
+      test(
+        "is idempotent for publish once the article is already published regardless of stale version"
+      ) {
         val events = Chunk(
-          SequencedArticleEvent(1L, ArticleDrafted(Slug.applyUnsafe("hello-world"), Title.applyUnsafe("Hello"), "body")),
+          SequencedArticleEvent(
+            1L,
+            ArticleDrafted(Slug.applyUnsafe("hello-world"), Title.applyUnsafe("Hello"), "body")
+          ),
           SequencedArticleEvent(2L, ArticlePublished(publishedAt = 999L)),
         )
         val store   = RecordingStore(initialEvents = events)
         val service = ArticleCommandService(store, FixedClock(1234L))
 
-        for
-          result <- service.publish(PublishArticleCommand(articleId, expectedVersion = 0L))
+        for result <- service.publish(PublishArticleCommand(articleId, expectedVersion = 0L))
         yield assertTrue(result == PublishResult.AlreadyPublished, store.appended.isEmpty)
       },
       test("treats append conflict as idempotent when reload shows the publish succeeded") {
         val drafted = SequencedArticleEvent(
           seq = 1L,
-          event = ArticleDrafted(Slug.applyUnsafe("hello-world"), Title.applyUnsafe("Hello"), "body"),
+          event =
+            ArticleDrafted(Slug.applyUnsafe("hello-world"), Title.applyUnsafe("Hello"), "body"),
         )
-        val published = SequencedArticleEvent(seq = 2L, event = ArticlePublished(publishedAt = 999L))
+        val published =
+          SequencedArticleEvent(seq = 2L, event = ArticlePublished(publishedAt = 999L))
         val store = RecordingStore(
           loadResults = List(
             ZIO.succeed(Chunk(drafted)),

--- a/apps/api/application/src/test/scala/morecat/application/ArticleCommandServiceSpec.scala
+++ b/apps/api/application/src/test/scala/morecat/application/ArticleCommandServiceSpec.scala
@@ -84,6 +84,20 @@ object ArticleCommandServiceSpec extends ZIOSpecDefault:
           _ <- service.createDraft(CreateDraftCommand(articleId, "hello-world", "Hello", "body"))
         yield assertTrue(store.created.isEmpty)
       },
+      test("is idempotent for the same initial draft even after later events") {
+        val drafted = ArticleDrafted(Slug.applyUnsafe("hello-world"), Title.applyUnsafe("Hello"), "body")
+        val store = RecordingStore(
+          initialEvents = Chunk(
+            SequencedArticleEvent(seq = 1L, event = drafted),
+            SequencedArticleEvent(seq = 2L, event = ArticlePublished(publishedAt = 999L)),
+          ),
+        )
+        val service = ArticleCommandService(store, FixedClock(123L))
+
+        for
+          _ <- service.createDraft(CreateDraftCommand(articleId, "hello-world", "Hello", "body"))
+        yield assertTrue(store.created.isEmpty)
+      },
       test("rejects the same articleId with different draft content") {
         val drafted = ArticleDrafted(Slug.applyUnsafe("hello-world"), Title.applyUnsafe("Hello"), "body")
         val store   = RecordingStore(initialEvents = Chunk(SequencedArticleEvent(seq = 1L, event = drafted)))
@@ -180,7 +194,7 @@ object ArticleCommandServiceSpec extends ZIOSpecDefault:
           result <- service.publish(PublishArticleCommand(articleId, expectedVersion = 1L))
         yield assertTrue(result == PublishResult.AlreadyPublished, store.appended.isEmpty)
       },
-      test("does not hide unrelated expected version conflicts when the article is already published") {
+      test("is idempotent for publish once the article is already published regardless of stale version") {
         val events = Chunk(
           SequencedArticleEvent(1L, ArticleDrafted(Slug.applyUnsafe("hello-world"), Title.applyUnsafe("Hello"), "body")),
           SequencedArticleEvent(2L, ArticlePublished(publishedAt = 999L)),
@@ -189,8 +203,8 @@ object ArticleCommandServiceSpec extends ZIOSpecDefault:
         val service = ArticleCommandService(store, FixedClock(1234L))
 
         for
-          exit <- service.publish(PublishArticleCommand(articleId, expectedVersion = 0L)).exit
-        yield assertTrue(exit == Exit.fail(CommandError.VersionConflict), store.appended.isEmpty)
+          result <- service.publish(PublishArticleCommand(articleId, expectedVersion = 0L))
+        yield assertTrue(result == PublishResult.AlreadyPublished, store.appended.isEmpty)
       },
       test("treats append conflict as idempotent when reload shows the publish succeeded") {
         val drafted = SequencedArticleEvent(

--- a/apps/api/application/src/test/scala/morecat/application/ArticleCommandServiceSpec.scala
+++ b/apps/api/application/src/test/scala/morecat/application/ArticleCommandServiceSpec.scala
@@ -112,5 +112,17 @@ object ArticleCommandServiceSpec extends ZIOSpecDefault:
           result <- service.publish(PublishArticleCommand(articleId, expectedVersion = 2L))
         yield assertTrue(result == PublishResult.AlreadyPublished, store.appended.isEmpty)
       },
+      test("does not hide expected version conflicts when the article is already published") {
+        val events = Chunk(
+          SequencedArticleEvent(1L, ArticleDrafted(Slug.applyUnsafe("hello-world"), Title.applyUnsafe("Hello"), "body")),
+          SequencedArticleEvent(2L, ArticlePublished(publishedAt = 999L)),
+        )
+        val store   = RecordingStore(initialEvents = events)
+        val service = ArticleCommandService(store, FixedClock(1234L))
+
+        for
+          exit <- service.publish(PublishArticleCommand(articleId, expectedVersion = 1L)).exit
+        yield assertTrue(exit == Exit.fail(CommandError.VersionConflict), store.appended.isEmpty)
+      },
     ),
   )

--- a/apps/api/application/src/test/scala/morecat/application/ArticleCommandServiceSpec.scala
+++ b/apps/api/application/src/test/scala/morecat/application/ArticleCommandServiceSpec.scala
@@ -234,7 +234,7 @@ object ArticleCommandServiceSpec extends ZIOSpecDefault:
         for result <- service.publish(PublishArticleCommand(articleId, expectedVersion = 0L))
         yield assertTrue(result == PublishResult.AlreadyPublished, store.appended.isEmpty)
       },
-      test("treats append conflict as idempotent when reload shows the publish succeeded") {
+      test("returns AlreadyPublished when append conflict reload shows the publish succeeded") {
         val drafted = SequencedArticleEvent(
           seq = 1L,
           event =
@@ -252,7 +252,7 @@ object ArticleCommandServiceSpec extends ZIOSpecDefault:
         val service = ArticleCommandService(store, FixedClock(999L))
 
         assertZIO(service.publish(PublishArticleCommand(articleId, expectedVersion = 1L)))(
-          equalTo(PublishResult.Published),
+          equalTo(PublishResult.AlreadyPublished),
         )
       },
     ),

--- a/apps/api/application/src/test/scala/morecat/application/ArticleCommandServiceSpec.scala
+++ b/apps/api/application/src/test/scala/morecat/application/ArticleCommandServiceSpec.scala
@@ -15,9 +15,9 @@ object ArticleCommandServiceSpec extends ZIOSpecDefault:
     createDraftResult: IO[EventStoreError, Unit] = ZIO.unit,
     appendResult: IO[EventStoreError, Unit] = ZIO.unit,
   ) extends ArticleEventStore:
-    var created: List[(ArticleId, ArticleDrafted)]      = Nil
+    var created: List[(ArticleId, ArticleDrafted)] = Nil
     var appended: List[(ArticleId, Long, ArticleEvent)] = Nil
-    private var remainingLoads                          = loadResults
+    private var remainingLoads = loadResults
     def createDraft(articleId: ArticleId, event: ArticleDrafted): IO[EventStoreError, Unit] =
       createDraftResult *> ZIO.succeed {
         created = created :+ (articleId, event)
@@ -44,7 +44,7 @@ object ArticleCommandServiceSpec extends ZIOSpecDefault:
   def spec = suite("ArticleCommandService")(
     suite("createDraft")(
       test("creates an ArticleDrafted event with validated slug and title") {
-        val store   = RecordingStore()
+        val store = RecordingStore()
         val service = ArticleCommandService(store, FixedClock(123L))
 
         for _ <- service.createDraft(CreateDraftCommand(articleId, "hello-world", "Hello", "body"))
@@ -80,7 +80,7 @@ object ArticleCommandServiceSpec extends ZIOSpecDefault:
         )
       },
       test("rejects invalid slug before touching the store") {
-        val store   = RecordingStore()
+        val store = RecordingStore()
         val service = ArticleCommandService(store, FixedClock(123L))
 
         for exit <- service
@@ -143,7 +143,7 @@ object ArticleCommandServiceSpec extends ZIOSpecDefault:
     ),
     suite("publish")(
       test("fails with ArticleNotFound when the stream does not exist") {
-        val store   = RecordingStore()
+        val store = RecordingStore()
         val service = ArticleCommandService(store, FixedClock(123L))
 
         assertZIO(service.publish(PublishArticleCommand(articleId, expectedVersion = 1L)).exit)(
@@ -156,7 +156,7 @@ object ArticleCommandServiceSpec extends ZIOSpecDefault:
           event =
             ArticleDrafted(Slug.applyUnsafe("hello-world"), Title.applyUnsafe("Hello"), "body"),
         )
-        val store   = RecordingStore(initialEvents = Chunk(drafted))
+        val store = RecordingStore(initialEvents = Chunk(drafted))
         val service = ArticleCommandService(store, FixedClock(999L))
 
         for result <- service.publish(PublishArticleCommand(articleId, expectedVersion = 1L))
@@ -198,7 +198,7 @@ object ArticleCommandServiceSpec extends ZIOSpecDefault:
           ),
           SequencedArticleEvent(2L, ArticlePublished(publishedAt = 999L)),
         )
-        val store   = RecordingStore(initialEvents = events)
+        val store = RecordingStore(initialEvents = events)
         val service = ArticleCommandService(store, FixedClock(1234L))
 
         for result <- service.publish(PublishArticleCommand(articleId, expectedVersion = 2L))
@@ -212,7 +212,7 @@ object ArticleCommandServiceSpec extends ZIOSpecDefault:
           ),
           SequencedArticleEvent(2L, ArticlePublished(publishedAt = 999L)),
         )
-        val store   = RecordingStore(initialEvents = events)
+        val store = RecordingStore(initialEvents = events)
         val service = ArticleCommandService(store, FixedClock(1234L))
 
         for result <- service.publish(PublishArticleCommand(articleId, expectedVersion = 1L))
@@ -228,7 +228,7 @@ object ArticleCommandServiceSpec extends ZIOSpecDefault:
           ),
           SequencedArticleEvent(2L, ArticlePublished(publishedAt = 999L)),
         )
-        val store   = RecordingStore(initialEvents = events)
+        val store = RecordingStore(initialEvents = events)
         val service = ArticleCommandService(store, FixedClock(1234L))
 
         for result <- service.publish(PublishArticleCommand(articleId, expectedVersion = 0L))

--- a/apps/api/application/src/test/scala/morecat/application/ArticleCommandServiceSpec.scala
+++ b/apps/api/application/src/test/scala/morecat/application/ArticleCommandServiceSpec.scala
@@ -79,6 +79,17 @@ object ArticleCommandServiceSpec extends ZIOSpecDefault:
           fails(equalTo(CommandError.StoreUnavailable)),
         )
       },
+      test("maps store unavailability while creating to StoreUnavailable") {
+        val store =
+          RecordingStore(createDraftResult = ZIO.fail(EventStoreError.Unavailable("down")))
+        val service = ArticleCommandService(store, FixedClock(123L))
+
+        assertZIO(
+          service.createDraft(CreateDraftCommand(articleId, "hello-world", "Hello", "body")).exit
+        )(
+          fails(equalTo(CommandError.StoreUnavailable)),
+        )
+      },
       test("rejects invalid slug before touching the store") {
         val store = RecordingStore()
         val service = ArticleCommandService(store, FixedClock(123L))
@@ -87,6 +98,15 @@ object ArticleCommandServiceSpec extends ZIOSpecDefault:
             .createDraft(CreateDraftCommand(articleId, "../bad", "Hello", "body"))
             .exit
         yield assertTrue(exit == Exit.fail(CommandError.InvalidSlug), store.created.isEmpty)
+      },
+      test("rejects invalid title before touching the store") {
+        val store = RecordingStore()
+        val service = ArticleCommandService(store, FixedClock(123L))
+
+        for exit <- service
+            .createDraft(CreateDraftCommand(articleId, "hello-world", "", "body"))
+            .exit
+        yield assertTrue(exit == Exit.fail(CommandError.InvalidTitle), store.created.isEmpty)
       },
       test("is idempotent for the same articleId and same draft content") {
         val drafted =
@@ -123,6 +143,40 @@ object ArticleCommandServiceSpec extends ZIOSpecDefault:
           service.createDraft(CreateDraftCommand(articleId, "hello-world", "Changed", "body")).exit
         )(
           fails(equalTo(CommandError.VersionConflict)),
+        )
+      },
+      test("keeps slug conflicts when reload does not show the requested draft") {
+        val otherDraft =
+          ArticleDrafted(Slug.applyUnsafe("hello-world"), Title.applyUnsafe("Other"), "body")
+        val store = RecordingStore(
+          loadResults = List(
+            ZIO.succeed(Chunk.empty),
+            ZIO.succeed(Chunk(SequencedArticleEvent(seq = 1L, event = otherDraft))),
+          ),
+          createDraftResult = ZIO.fail(EventStoreError.SlugAlreadyReserved),
+        )
+        val service = ArticleCommandService(store, FixedClock(123L))
+
+        assertZIO(
+          service.createDraft(CreateDraftCommand(articleId, "hello-world", "Hello", "body")).exit
+        )(
+          fails(equalTo(CommandError.SlugConflict)),
+        )
+      },
+      test("maps reload unavailability after create conflict to StoreUnavailable") {
+        val store = RecordingStore(
+          loadResults = List(
+            ZIO.succeed(Chunk.empty),
+            ZIO.fail(EventStoreError.Unavailable("down")),
+          ),
+          createDraftResult = ZIO.fail(EventStoreError.VersionConflict),
+        )
+        val service = ArticleCommandService(store, FixedClock(123L))
+
+        assertZIO(
+          service.createDraft(CreateDraftCommand(articleId, "hello-world", "Hello", "body")).exit
+        )(
+          fails(equalTo(CommandError.StoreUnavailable)),
         )
       },
       test("treats create conflict as idempotent when reload shows the same draft") {
@@ -179,6 +233,22 @@ object ArticleCommandServiceSpec extends ZIOSpecDefault:
 
         assertZIO(service.publish(PublishArticleCommand(articleId, expectedVersion = 0L)).exit)(
           fails(equalTo(CommandError.VersionConflict)),
+        )
+      },
+      test("maps append unavailability to StoreUnavailable") {
+        val drafted = SequencedArticleEvent(
+          seq = 1L,
+          event =
+            ArticleDrafted(Slug.applyUnsafe("hello-world"), Title.applyUnsafe("Hello"), "body"),
+        )
+        val store = RecordingStore(
+          initialEvents = Chunk(drafted),
+          appendResult = ZIO.fail(EventStoreError.Unavailable("down")),
+        )
+        val service = ArticleCommandService(store, FixedClock(999L))
+
+        assertZIO(service.publish(PublishArticleCommand(articleId, expectedVersion = 1L)).exit)(
+          fails(equalTo(CommandError.StoreUnavailable)),
         )
       },
       test("maps store unavailability while loading to StoreUnavailable") {
@@ -253,6 +323,44 @@ object ArticleCommandServiceSpec extends ZIOSpecDefault:
 
         assertZIO(service.publish(PublishArticleCommand(articleId, expectedVersion = 1L)))(
           equalTo(PublishResult.AlreadyPublished),
+        )
+      },
+      test("keeps append conflicts when reload does not show a published article") {
+        val drafted = SequencedArticleEvent(
+          seq = 1L,
+          event =
+            ArticleDrafted(Slug.applyUnsafe("hello-world"), Title.applyUnsafe("Hello"), "body"),
+        )
+        val store = RecordingStore(
+          loadResults = List(
+            ZIO.succeed(Chunk(drafted)),
+            ZIO.succeed(Chunk(drafted)),
+          ),
+          appendResult = ZIO.fail(EventStoreError.VersionConflict),
+        )
+        val service = ArticleCommandService(store, FixedClock(999L))
+
+        assertZIO(service.publish(PublishArticleCommand(articleId, expectedVersion = 1L)).exit)(
+          fails(equalTo(CommandError.VersionConflict)),
+        )
+      },
+      test("maps reload unavailability after append conflict to StoreUnavailable") {
+        val drafted = SequencedArticleEvent(
+          seq = 1L,
+          event =
+            ArticleDrafted(Slug.applyUnsafe("hello-world"), Title.applyUnsafe("Hello"), "body"),
+        )
+        val store = RecordingStore(
+          loadResults = List(
+            ZIO.succeed(Chunk(drafted)),
+            ZIO.fail(EventStoreError.Unavailable("down")),
+          ),
+          appendResult = ZIO.fail(EventStoreError.VersionConflict),
+        )
+        val service = ArticleCommandService(store, FixedClock(999L))
+
+        assertZIO(service.publish(PublishArticleCommand(articleId, expectedVersion = 1L)).exit)(
+          fails(equalTo(CommandError.StoreUnavailable)),
         )
       },
     ),

--- a/apps/api/application/src/test/scala/morecat/application/ArticleCommandServiceSpec.scala
+++ b/apps/api/application/src/test/scala/morecat/application/ArticleCommandServiceSpec.scala
@@ -76,7 +76,7 @@ object ArticleCommandServiceSpec extends ZIOSpecDefault:
         assertZIO(
           service.createDraft(CreateDraftCommand(articleId, "hello-world", "Hello", "body")).exit
         )(
-          fails(equalTo(CommandError.StoreUnavailable("down"))),
+          fails(equalTo(CommandError.StoreUnavailable)),
         )
       },
       test("rejects invalid slug before touching the store") {
@@ -187,7 +187,7 @@ object ArticleCommandServiceSpec extends ZIOSpecDefault:
         val service = ArticleCommandService(store, FixedClock(999L))
 
         assertZIO(service.publish(PublishArticleCommand(articleId, expectedVersion = 1L)).exit)(
-          fails(equalTo(CommandError.StoreUnavailable("down"))),
+          fails(equalTo(CommandError.StoreUnavailable)),
         )
       },
       test("is idempotent when the article is already published") {

--- a/apps/api/application/src/test/scala/morecat/application/PublishedArticleServiceSpec.scala
+++ b/apps/api/application/src/test/scala/morecat/application/PublishedArticleServiceSpec.scala
@@ -43,7 +43,7 @@ object PublishedArticleServiceSpec extends ZIOSpecDefault:
       val service = PublishedArticleService(query)
 
       assertZIO(service.getBySlug("hello-world").exit)(
-        fails(equalTo(PublishedArticleError.QueryUnavailable("down"))),
+        fails(equalTo(PublishedArticleError.QueryUnavailable)),
       )
     },
     test("rejects invalid slug before querying") {

--- a/apps/api/application/src/test/scala/morecat/application/PublishedArticleServiceSpec.scala
+++ b/apps/api/application/src/test/scala/morecat/application/PublishedArticleServiceSpec.scala
@@ -15,8 +15,9 @@ object PublishedArticleServiceSpec extends ZIOSpecDefault:
     publishedAt = 999L,
   )
 
-  private final class StubQuery(result: IO[QueryError, Option[PublishedArticle]]) extends PublishedArticleQuery:
-    var requested: List[Slug] = Nil
+  private final class StubQuery(result: IO[QueryError, Option[PublishedArticle]])
+      extends PublishedArticleQuery:
+    var requested: List[Slug]                                            = Nil
     def findBySlug(slug: Slug): IO[QueryError, Option[PublishedArticle]] =
       result <* ZIO.succeed {
         requested = requested :+ slug
@@ -33,7 +34,9 @@ object PublishedArticleServiceSpec extends ZIOSpecDefault:
       val query   = StubQuery(ZIO.succeed(None))
       val service = PublishedArticleService(query)
 
-      assertZIO(service.getBySlug("hello-world").exit)(fails(equalTo(PublishedArticleError.NotFound)))
+      assertZIO(service.getBySlug("hello-world").exit)(
+        fails(equalTo(PublishedArticleError.NotFound))
+      )
     },
     test("maps query unavailability to QueryUnavailable") {
       val query   = StubQuery(ZIO.fail(QueryError.Unavailable("down")))
@@ -47,8 +50,10 @@ object PublishedArticleServiceSpec extends ZIOSpecDefault:
       val query   = StubQuery(ZIO.succeed(Some(article)))
       val service = PublishedArticleService(query)
 
-      for
-        exit <- service.getBySlug("../bad").exit
-      yield assertTrue(exit == Exit.fail(PublishedArticleError.InvalidSlug), query.requested.isEmpty)
+      for exit <- service.getBySlug("../bad").exit
+      yield assertTrue(
+        exit == Exit.fail(PublishedArticleError.InvalidSlug),
+        query.requested.isEmpty
+      )
     },
   )

--- a/apps/api/application/src/test/scala/morecat/application/PublishedArticleServiceSpec.scala
+++ b/apps/api/application/src/test/scala/morecat/application/PublishedArticleServiceSpec.scala
@@ -1,0 +1,46 @@
+package morecat.application
+
+import morecat.domain.*
+import zio.*
+import zio.test.Assertion.*
+import zio.test.*
+
+object PublishedArticleServiceSpec extends ZIOSpecDefault:
+
+  private val article = PublishedArticle(
+    id = ArticleId.fromString("018f4edc-1f5a-7c4b-aef9-000000000001"),
+    slug = Slug.applyUnsafe("hello-world"),
+    title = Title.applyUnsafe("Hello"),
+    body = "body",
+    publishedAt = 999L,
+  )
+
+  private final class StubQuery(result: IO[QueryError, Option[PublishedArticle]]) extends PublishedArticleQuery:
+    var requested: List[Slug] = Nil
+    def findBySlug(slug: Slug): IO[QueryError, Option[PublishedArticle]] =
+      result <* ZIO.succeed {
+        requested = requested :+ slug
+      }
+
+  def spec = suite("PublishedArticleService")(
+    test("returns the published article for a valid slug") {
+      val query   = StubQuery(ZIO.succeed(Some(article)))
+      val service = PublishedArticleService(query)
+
+      assertZIO(service.getBySlug("hello-world"))(equalTo(article))
+    },
+    test("returns NotFound when no published projection exists") {
+      val query   = StubQuery(ZIO.succeed(None))
+      val service = PublishedArticleService(query)
+
+      assertZIO(service.getBySlug("hello-world").exit)(fails(equalTo(PublishedArticleError.NotFound)))
+    },
+    test("rejects invalid slug before querying") {
+      val query   = StubQuery(ZIO.succeed(Some(article)))
+      val service = PublishedArticleService(query)
+
+      for
+        exit <- service.getBySlug("../bad").exit
+      yield assertTrue(exit == Exit.fail(PublishedArticleError.InvalidSlug), query.requested.isEmpty)
+    },
+  )

--- a/apps/api/application/src/test/scala/morecat/application/PublishedArticleServiceSpec.scala
+++ b/apps/api/application/src/test/scala/morecat/application/PublishedArticleServiceSpec.scala
@@ -35,6 +35,14 @@ object PublishedArticleServiceSpec extends ZIOSpecDefault:
 
       assertZIO(service.getBySlug("hello-world").exit)(fails(equalTo(PublishedArticleError.NotFound)))
     },
+    test("maps query unavailability to QueryUnavailable") {
+      val query   = StubQuery(ZIO.fail(QueryError.Unavailable("down")))
+      val service = PublishedArticleService(query)
+
+      assertZIO(service.getBySlug("hello-world").exit)(
+        fails(equalTo(PublishedArticleError.QueryUnavailable("down"))),
+      )
+    },
     test("rejects invalid slug before querying") {
       val query   = StubQuery(ZIO.succeed(Some(article)))
       val service = PublishedArticleService(query)

--- a/apps/api/application/src/test/scala/morecat/application/PublishedArticleServiceSpec.scala
+++ b/apps/api/application/src/test/scala/morecat/application/PublishedArticleServiceSpec.scala
@@ -17,7 +17,7 @@ object PublishedArticleServiceSpec extends ZIOSpecDefault:
 
   private final class StubQuery(result: IO[QueryError, Option[PublishedArticle]])
       extends PublishedArticleQuery:
-    var requested: List[Slug]                                            = Nil
+    var requested: List[Slug] = Nil
     def findBySlug(slug: Slug): IO[QueryError, Option[PublishedArticle]] =
       result <* ZIO.succeed {
         requested = requested :+ slug
@@ -25,13 +25,13 @@ object PublishedArticleServiceSpec extends ZIOSpecDefault:
 
   def spec = suite("PublishedArticleService")(
     test("returns the published article for a valid slug") {
-      val query   = StubQuery(ZIO.succeed(Some(article)))
+      val query = StubQuery(ZIO.succeed(Some(article)))
       val service = PublishedArticleService(query)
 
       assertZIO(service.getBySlug("hello-world"))(equalTo(article))
     },
     test("returns NotFound when no published projection exists") {
-      val query   = StubQuery(ZIO.succeed(None))
+      val query = StubQuery(ZIO.succeed(None))
       val service = PublishedArticleService(query)
 
       assertZIO(service.getBySlug("hello-world").exit)(
@@ -39,7 +39,7 @@ object PublishedArticleServiceSpec extends ZIOSpecDefault:
       )
     },
     test("maps query unavailability to QueryUnavailable") {
-      val query   = StubQuery(ZIO.fail(QueryError.Unavailable("down")))
+      val query = StubQuery(ZIO.fail(QueryError.Unavailable("down")))
       val service = PublishedArticleService(query)
 
       assertZIO(service.getBySlug("hello-world").exit)(
@@ -47,7 +47,7 @@ object PublishedArticleServiceSpec extends ZIOSpecDefault:
       )
     },
     test("rejects invalid slug before querying") {
-      val query   = StubQuery(ZIO.succeed(Some(article)))
+      val query = StubQuery(ZIO.succeed(Some(article)))
       val service = PublishedArticleService(query)
 
       for exit <- service.getBySlug("../bad").exit

--- a/apps/api/build.sbt
+++ b/apps/api/build.sbt
@@ -59,10 +59,3 @@ lazy val infrastructure = project
     ),
     testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework"),
   )
-
-lazy val root = (project in file("."))
-  .aggregate(domain, application, infrastructure)
-  .settings(
-    name := "morecat-api",
-    publish / skip := true,
-  )

--- a/apps/api/build.sbt
+++ b/apps/api/build.sbt
@@ -18,6 +18,9 @@ ThisBuild / scalacOptions ++= Seq(
 )
 
 ThisBuild / coverageEnabled := false
+ThisBuild / coverageMinimumStmtTotal := 100
+ThisBuild / coverageMinimumBranchTotal := 100
+ThisBuild / coverageFailOnMinimum := true
 
 lazy val root = project
   .in(file("."))

--- a/apps/api/build.sbt
+++ b/apps/api/build.sbt
@@ -17,6 +17,16 @@ ThisBuild / scalacOptions ++= Seq(
   "-Wunused:all",
 )
 
+ThisBuild / coverageEnabled := false
+
+lazy val root = project
+  .in(file("."))
+  .aggregate(domain, application, infrastructure)
+  .settings(
+    name := "morecat-api",
+    publish / skip := true,
+  )
+
 // 純粋ドメイン: Article イベント ADT・値オブジェクト(Iron)・projection fold。
 // IO や wire フォーマット(JSON 等)への依存を載せないことをビルドで強制する。
 // JSON codec は infrastructure 層の関心事。RMU(Rust) とはコードを共有せず、

--- a/apps/api/build.sbt
+++ b/apps/api/build.sbt
@@ -1,9 +1,10 @@
 // morecat API — JVM 単一 sbt ビルド（ビルドルート = apps/api）。
-// ヘクサゴナル: domain(純粋) <- application <- infrastructure <- bootstrap（後者3つはタスク2以降）。
+// ヘクサゴナル: domain(純粋) <- application <- infrastructure <- bootstrap。
 
 val scala3      = "3.8.4"
 val zioVersion  = "2.1.26"
 val ironVersion = "3.3.1"
+val zioJsonVersion = "0.9.0"
 
 ThisBuild / scalaVersion := scala3
 ThisBuild / organization := "morecat"
@@ -32,8 +33,35 @@ lazy val domain = project
     testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework"),
   )
 
+lazy val application = project
+  .in(file("application"))
+  .dependsOn(domain)
+  .settings(
+    name := "morecat-application",
+    libraryDependencies ++= Seq(
+      "dev.zio" %% "zio"          % zioVersion,
+      "dev.zio" %% "zio-test"     % zioVersion % Test,
+      "dev.zio" %% "zio-test-sbt" % zioVersion % Test,
+    ),
+    testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework"),
+  )
+
+lazy val infrastructure = project
+  .in(file("infrastructure"))
+  .dependsOn(application)
+  .settings(
+    name := "morecat-infrastructure",
+    libraryDependencies ++= Seq(
+      "dev.zio" %% "zio"          % zioVersion,
+      "dev.zio" %% "zio-json"     % zioJsonVersion,
+      "dev.zio" %% "zio-test"     % zioVersion % Test,
+      "dev.zio" %% "zio-test-sbt" % zioVersion % Test,
+    ),
+    testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework"),
+  )
+
 lazy val root = (project in file("."))
-  .aggregate(domain)
+  .aggregate(domain, application, infrastructure)
   .settings(
     name := "morecat-api",
     publish / skip := true,

--- a/apps/api/domain/src/main/scala/morecat/domain/ArticleEvent.scala
+++ b/apps/api/domain/src/main/scala/morecat/domain/ArticleEvent.scala
@@ -16,10 +16,16 @@ final case class ArticleDrafted(
     title: Title,
     body: String,
 ) extends ArticleEvent:
-  val schemaVersion: Int = 1
+  val schemaVersion: Int = ArticleDrafted.CurrentSchemaVersion
+
+object ArticleDrafted:
+  val CurrentSchemaVersion: Int = 1
 
 /** 公開。publishedAt はサーバ時刻（epoch millis）。 */
 final case class ArticlePublished(
     publishedAt: Long,
 ) extends ArticleEvent:
-  val schemaVersion: Int = 1
+  val schemaVersion: Int = ArticlePublished.CurrentSchemaVersion
+
+object ArticlePublished:
+  val CurrentSchemaVersion: Int = 1

--- a/apps/api/domain/src/main/scala/morecat/domain/ArticleEvent.scala
+++ b/apps/api/domain/src/main/scala/morecat/domain/ArticleEvent.scala
@@ -1,20 +1,20 @@
 package morecat.domain
 
-/** Article のドメインイベント（中粒度・意図整合）。イベントが唯一の真実。
-  *
-  * 集約 ID はストリームのパス（articles/{id}/events/{seq}）が持つため payload には含めない。
-  * `schemaVersion` は各イベント型の**現行スキーマ版**を表す固定値。新規生成イベントは常に
-  * 現行版であり、古い版は infrastructure の decode/upcast 時に wire 上でのみ存在する。
-  * JSON 等の wire フォーマットは infrastructure 層の関心事であり、domain は関知しない。
-  */
+/**
+ * Article のドメインイベント（中粒度・意図整合）。イベントが唯一の真実。
+ *
+ * 集約 ID はストリームのパス（articles/{id}/events/{seq}）が持つため payload には含めない。 `schemaVersion`
+ * は各イベント型の**現行スキーマ版**を表す固定値。新規生成イベントは常に 現行版であり、古い版は infrastructure の decode/upcast 時に wire
+ * 上でのみ存在する。 JSON 等の wire フォーマットは infrastructure 層の関心事であり、domain は関知しない。
+ */
 sealed trait ArticleEvent:
   def schemaVersion: Int
 
 /** 下書き作成（初期 slug/title/body）。tags は slice2 以降。 */
 final case class ArticleDrafted(
-    slug: Slug,
-    title: Title,
-    body: String,
+  slug: Slug,
+  title: Title,
+  body: String,
 ) extends ArticleEvent:
   val schemaVersion: Int = ArticleDrafted.CurrentSchemaVersion
 
@@ -23,7 +23,7 @@ object ArticleDrafted:
 
 /** 公開。publishedAt はサーバ時刻（epoch millis）。 */
 final case class ArticlePublished(
-    publishedAt: Long,
+  publishedAt: Long,
 ) extends ArticleEvent:
   val schemaVersion: Int = ArticlePublished.CurrentSchemaVersion
 

--- a/apps/api/domain/src/main/scala/morecat/domain/ArticleId.scala
+++ b/apps/api/domain/src/main/scala/morecat/domain/ArticleId.scala
@@ -1,8 +1,8 @@
 package morecat.domain
 
-/** 集約 ID。ドメインにとっては不透明な識別子。
-  * 実体の採番・表現（UUIDv7 等）と検証は infrastructure の責務。
-  */
+/**
+ * 集約 ID。ドメインにとっては不透明な識別子。 実体の採番・表現（UUIDv7 等）と検証は infrastructure の責務。
+ */
 opaque type ArticleId = String
 
 object ArticleId:

--- a/apps/api/domain/src/main/scala/morecat/domain/Slug.scala
+++ b/apps/api/domain/src/main/scala/morecat/domain/Slug.scala
@@ -5,9 +5,9 @@ import io.github.iltotore.iron.constraint.all.*
 
 /** 公開 URL の slug。小文字英数字とハイフン区切り（先頭/末尾・連続ハイフン不可）。 */
 type SlugConstraint = Match["^[a-z0-9]+(?:-[a-z0-9]+)*$"]
-type Slug           = String :| SlugConstraint
+type Slug = String :| SlugConstraint
 
 object Slug:
   /** smart constructor（実行時検証）。 */
   def either(value: String): Either[String, Slug] = value.refineEither[SlugConstraint]
-  def applyUnsafe(value: String): Slug            = value.refineUnsafe[SlugConstraint]
+  def applyUnsafe(value: String): Slug = value.refineUnsafe[SlugConstraint]

--- a/apps/api/domain/src/main/scala/morecat/domain/Slug.scala
+++ b/apps/api/domain/src/main/scala/morecat/domain/Slug.scala
@@ -5,9 +5,9 @@ import io.github.iltotore.iron.constraint.all.*
 
 /** 公開 URL の slug。小文字英数字とハイフン区切り（先頭/末尾・連続ハイフン不可）。 */
 type SlugConstraint = Match["^[a-z0-9]+(?:-[a-z0-9]+)*$"]
-type Slug = String :| SlugConstraint
+type Slug           = String :| SlugConstraint
 
 object Slug:
   /** smart constructor（実行時検証）。 */
   def either(value: String): Either[String, Slug] = value.refineEither[SlugConstraint]
-  def applyUnsafe(value: String): Slug = value.refineUnsafe[SlugConstraint]
+  def applyUnsafe(value: String): Slug            = value.refineUnsafe[SlugConstraint]

--- a/apps/api/domain/src/main/scala/morecat/domain/Title.scala
+++ b/apps/api/domain/src/main/scala/morecat/domain/Title.scala
@@ -9,4 +9,4 @@ type Title           = String :| TitleConstraint
 
 object Title:
   def either(value: String): Either[String, Title] = value.refineEither[TitleConstraint]
-  def applyUnsafe(value: String): Title             = value.refineUnsafe[TitleConstraint]
+  def applyUnsafe(value: String): Title            = value.refineUnsafe[TitleConstraint]

--- a/apps/api/domain/src/main/scala/morecat/domain/Title.scala
+++ b/apps/api/domain/src/main/scala/morecat/domain/Title.scala
@@ -5,8 +5,8 @@ import io.github.iltotore.iron.constraint.all.*
 
 /** 記事タイトル（非空）。 */
 type TitleConstraint = Not[Empty]
-type Title           = String :| TitleConstraint
+type Title = String :| TitleConstraint
 
 object Title:
   def either(value: String): Either[String, Title] = value.refineEither[TitleConstraint]
-  def applyUnsafe(value: String): Title            = value.refineUnsafe[TitleConstraint]
+  def applyUnsafe(value: String): Title = value.refineUnsafe[TitleConstraint]

--- a/apps/api/domain/src/test/scala/morecat/domain/DomainSpec.scala
+++ b/apps/api/domain/src/test/scala/morecat/domain/DomainSpec.scala
@@ -54,8 +54,11 @@ object DomainSpec extends ZIOSpecDefault:
       // schemaVersion は wire 契約の核。現行版を lock して不用意な変更を検出する。
       test("schemaVersion is fixed to the current version (1)") {
         assertTrue(
-          ArticleDrafted(Slug.applyUnsafe("a"), Title.applyUnsafe("t"), "body").schemaVersion == 1,
-          ArticlePublished(publishedAt = 0L).schemaVersion == 1,
+          ArticleDrafted(Slug.applyUnsafe("a"), Title.applyUnsafe("t"), "body").schemaVersion ==
+            ArticleDrafted.CurrentSchemaVersion,
+          ArticlePublished(publishedAt = 0L).schemaVersion == ArticlePublished.CurrentSchemaVersion,
+          ArticleDrafted.CurrentSchemaVersion == 1,
+          ArticlePublished.CurrentSchemaVersion == 1,
         )
       },
     ),

--- a/apps/api/domain/src/test/scala/morecat/domain/DomainSpec.scala
+++ b/apps/api/domain/src/test/scala/morecat/domain/DomainSpec.scala
@@ -15,12 +15,12 @@ object DomainSpec extends ZIOSpecDefault:
   /** 既知の不正パターン。いずれも正規表現を確実に破る。 */
   private val invalidSlug: Gen[Any, String] =
     Gen.oneOf(
-      Gen.const(""),               // 空
-      validSlug.map("-" + _),      // 先頭ハイフン
-      validSlug.map(_ + "-"),      // 末尾ハイフン
+      Gen.const(""),                 // 空
+      validSlug.map("-" + _),        // 先頭ハイフン
+      validSlug.map(_ + "-"),        // 末尾ハイフン
       validSlug.map(s => s"$s--$s"), // 連続ハイフン
-      validSlug.map(_ + "A"),      // 大文字混入
-      validSlug.map(_ + " "),      // 空白混入
+      validSlug.map(_ + "A"),        // 大文字混入
+      validSlug.map(_ + " "),        // 空白混入
     )
 
   def spec = suite("domain")(

--- a/apps/api/domain/src/test/scala/morecat/domain/DomainSpec.scala
+++ b/apps/api/domain/src/test/scala/morecat/domain/DomainSpec.scala
@@ -15,12 +15,12 @@ object DomainSpec extends ZIOSpecDefault:
   /** 既知の不正パターン。いずれも正規表現を確実に破る。 */
   private val invalidSlug: Gen[Any, String] =
     Gen.oneOf(
-      Gen.const(""),                 // 空
-      validSlug.map("-" + _),        // 先頭ハイフン
-      validSlug.map(_ + "-"),        // 末尾ハイフン
+      Gen.const(""), // 空
+      validSlug.map("-" + _), // 先頭ハイフン
+      validSlug.map(_ + "-"), // 末尾ハイフン
       validSlug.map(s => s"$s--$s"), // 連続ハイフン
-      validSlug.map(_ + "A"),        // 大文字混入
-      validSlug.map(_ + " "),        // 空白混入
+      validSlug.map(_ + "A"), // 大文字混入
+      validSlug.map(_ + " "), // 空白混入
     )
 
   def spec = suite("domain")(

--- a/apps/api/infrastructure/src/main/scala/morecat/infrastructure/json/ArticleEventJsonCodec.scala
+++ b/apps/api/infrastructure/src/main/scala/morecat/infrastructure/json/ArticleEventJsonCodec.scala
@@ -36,11 +36,11 @@ object ArticleEventJsonCodec:
     wire.eventType match
       case "ArticleDrafted" =>
         for
-          _     <- requireSchemaVersion(wire.schemaVersion, ArticleDrafted.CurrentSchemaVersion)
-          slug  <- required("slug", wire.slug).flatMap(Slug.either)
+          _ <- requireSchemaVersion(wire.schemaVersion, ArticleDrafted.CurrentSchemaVersion)
+          slug <- required("slug", wire.slug).flatMap(Slug.either)
           title <- required("title", wire.title).flatMap(Title.either)
-          body  <- required("body", wire.body)
-          _     <- absent("publishedAt", wire.publishedAt)
+          body <- required("body", wire.body)
+          _ <- absent("publishedAt", wire.publishedAt)
         yield ArticleDrafted(slug, title, body)
       case "ArticlePublished" =>
         for

--- a/apps/api/infrastructure/src/main/scala/morecat/infrastructure/json/ArticleEventJsonCodec.scala
+++ b/apps/api/infrastructure/src/main/scala/morecat/infrastructure/json/ArticleEventJsonCodec.scala
@@ -44,10 +44,10 @@ object ArticleEventJsonCodec:
         yield ArticleDrafted(slug, title, body)
       case "ArticlePublished" =>
         for
-          _           <- requireSchemaVersion(wire.schemaVersion, ArticlePublished.CurrentSchemaVersion)
-          _           <- absent("slug", wire.slug)
-          _           <- absent("title", wire.title)
-          _           <- absent("body", wire.body)
+          _ <- requireSchemaVersion(wire.schemaVersion, ArticlePublished.CurrentSchemaVersion)
+          _ <- absent("slug", wire.slug)
+          _ <- absent("title", wire.title)
+          _ <- absent("body", wire.body)
           publishedAt <- required("publishedAt", wire.publishedAt)
         yield ArticlePublished(publishedAt)
       case other =>
@@ -64,10 +64,10 @@ object ArticleEventJsonCodec:
 
 @jsonNoExtraFields
 private final case class WireArticleEvent(
-    eventType: String,
-    schemaVersion: Int,
-    slug: Option[String],
-    title: Option[String],
-    body: Option[String],
-    publishedAt: Option[Long],
+  eventType: String,
+  schemaVersion: Int,
+  slug: Option[String],
+  title: Option[String],
+  body: Option[String],
+  publishedAt: Option[Long],
 ) derives JsonCodec

--- a/apps/api/infrastructure/src/main/scala/morecat/infrastructure/json/ArticleEventJsonCodec.scala
+++ b/apps/api/infrastructure/src/main/scala/morecat/infrastructure/json/ArticleEventJsonCodec.scala
@@ -6,68 +6,62 @@ import zio.json.*
 object ArticleEventJsonCodec:
 
   def encode(event: ArticleEvent): String =
-    toWire(event).toJson
-
-  def decode(json: String): Either[String, ArticleEvent] =
-    json.fromJson[WireArticleEvent].flatMap(toDomain)
-
-  private def toWire(event: ArticleEvent): WireArticleEvent =
     event match
       case ArticleDrafted(slug, title, body) =>
-        WireArticleEvent(
+        WireArticleDrafted(
           eventType = "ArticleDrafted",
           schemaVersion = ArticleDrafted.CurrentSchemaVersion,
-          slug = Some(slug),
-          title = Some(title),
-          body = Some(body),
-          publishedAt = None,
-        )
+          slug = slug,
+          title = title,
+          body = body,
+        ).toJson
       case ArticlePublished(publishedAt) =>
-        WireArticleEvent(
+        WireArticlePublished(
           eventType = "ArticlePublished",
           schemaVersion = ArticlePublished.CurrentSchemaVersion,
-          slug = None,
-          title = None,
-          body = None,
-          publishedAt = Some(publishedAt),
-        )
+          publishedAt = publishedAt,
+        ).toJson
 
-  private def toDomain(wire: WireArticleEvent): Either[String, ArticleEvent] =
-    wire.eventType match
-      case "ArticleDrafted" =>
-        for
-          _ <- requireSchemaVersion(wire.schemaVersion, ArticleDrafted.CurrentSchemaVersion)
-          slug <- required("slug", wire.slug).flatMap(Slug.either)
-          title <- required("title", wire.title).flatMap(Title.either)
-          body <- required("body", wire.body)
-          _ <- absent("publishedAt", wire.publishedAt)
-        yield ArticleDrafted(slug, title, body)
-      case "ArticlePublished" =>
-        for
-          _ <- requireSchemaVersion(wire.schemaVersion, ArticlePublished.CurrentSchemaVersion)
-          _ <- absent("slug", wire.slug)
-          _ <- absent("title", wire.title)
-          _ <- absent("body", wire.body)
-          publishedAt <- required("publishedAt", wire.publishedAt)
-        yield ArticlePublished(publishedAt)
-      case other =>
-        Left(s"unsupported eventType: $other")
+  def decode(json: String): Either[String, ArticleEvent] =
+    json
+      .fromJson[WireArticleHeader]
+      .flatMap: header =>
+        header.eventType match
+          case "ArticleDrafted" =>
+            json.fromJson[WireArticleDrafted].flatMap(toDomain)
+          case "ArticlePublished" =>
+            json.fromJson[WireArticlePublished].flatMap(toDomain)
+          case other =>
+            Left(s"unsupported eventType: $other")
+
+  private def toDomain(wire: WireArticleDrafted): Either[String, ArticleEvent] =
+    for
+      _ <- requireSchemaVersion(wire.schemaVersion, ArticleDrafted.CurrentSchemaVersion)
+      slug <- Slug.either(wire.slug)
+      title <- Title.either(wire.title)
+    yield ArticleDrafted(slug, title, wire.body)
+
+  private def toDomain(wire: WireArticlePublished): Either[String, ArticleEvent] =
+    for _ <- requireSchemaVersion(wire.schemaVersion, ArticlePublished.CurrentSchemaVersion)
+    yield ArticlePublished(wire.publishedAt)
 
   private def requireSchemaVersion(actual: Int, expected: Int): Either[String, Unit] =
     Either.cond(actual == expected, (), s"unsupported schemaVersion: $actual")
 
-  private def required[A](field: String, value: Option[A]): Either[String, A] =
-    value.toRight(s"missing required field: $field")
-
-  private def absent[A](field: String, value: Option[A]): Either[String, Unit] =
-    Either.cond(value.isEmpty, (), s"unexpected field for event type: $field")
+private final case class WireArticleHeader(eventType: String) derives JsonDecoder
 
 @jsonNoExtraFields
-private final case class WireArticleEvent(
+private final case class WireArticleDrafted(
   eventType: String,
   schemaVersion: Int,
-  slug: Option[String],
-  title: Option[String],
-  body: Option[String],
-  publishedAt: Option[Long],
+  slug: String,
+  title: String,
+  body: String,
+) derives JsonCodec
+
+@jsonNoExtraFields
+private final case class WireArticlePublished(
+  eventType: String,
+  schemaVersion: Int,
+  publishedAt: Long,
 ) derives JsonCodec

--- a/apps/api/infrastructure/src/main/scala/morecat/infrastructure/json/ArticleEventJsonCodec.scala
+++ b/apps/api/infrastructure/src/main/scala/morecat/infrastructure/json/ArticleEventJsonCodec.scala
@@ -1,0 +1,73 @@
+package morecat.infrastructure.json
+
+import morecat.domain.*
+import zio.json.*
+
+object ArticleEventJsonCodec:
+
+  def encode(event: ArticleEvent): String =
+    toWire(event).toJson
+
+  def decode(json: String): Either[String, ArticleEvent] =
+    json.fromJson[WireArticleEvent].flatMap(toDomain)
+
+  private def toWire(event: ArticleEvent): WireArticleEvent =
+    event match
+      case ArticleDrafted(slug, title, body) =>
+        WireArticleEvent(
+          eventType = "ArticleDrafted",
+          schemaVersion = ArticleDrafted.CurrentSchemaVersion,
+          slug = Some(slug),
+          title = Some(title),
+          body = Some(body),
+          publishedAt = None,
+        )
+      case ArticlePublished(publishedAt) =>
+        WireArticleEvent(
+          eventType = "ArticlePublished",
+          schemaVersion = ArticlePublished.CurrentSchemaVersion,
+          slug = None,
+          title = None,
+          body = None,
+          publishedAt = Some(publishedAt),
+        )
+
+  private def toDomain(wire: WireArticleEvent): Either[String, ArticleEvent] =
+    wire.eventType match
+      case "ArticleDrafted" =>
+        for
+          _     <- requireSchemaVersion(wire.schemaVersion, ArticleDrafted.CurrentSchemaVersion)
+          slug  <- required("slug", wire.slug).flatMap(Slug.either)
+          title <- required("title", wire.title).flatMap(Title.either)
+          body  <- required("body", wire.body)
+          _     <- absent("publishedAt", wire.publishedAt)
+        yield ArticleDrafted(slug, title, body)
+      case "ArticlePublished" =>
+        for
+          _           <- requireSchemaVersion(wire.schemaVersion, ArticlePublished.CurrentSchemaVersion)
+          _           <- absent("slug", wire.slug)
+          _           <- absent("title", wire.title)
+          _           <- absent("body", wire.body)
+          publishedAt <- required("publishedAt", wire.publishedAt)
+        yield ArticlePublished(publishedAt)
+      case other =>
+        Left(s"unsupported eventType: $other")
+
+  private def requireSchemaVersion(actual: Int, expected: Int): Either[String, Unit] =
+    Either.cond(actual == expected, (), s"unsupported schemaVersion: $actual")
+
+  private def required[A](field: String, value: Option[A]): Either[String, A] =
+    value.toRight(s"missing required field: $field")
+
+  private def absent[A](field: String, value: Option[A]): Either[String, Unit] =
+    Either.cond(value.isEmpty, (), s"unexpected field for event type: $field")
+
+@jsonNoExtraFields
+private final case class WireArticleEvent(
+    eventType: String,
+    schemaVersion: Int,
+    slug: Option[String],
+    title: Option[String],
+    body: Option[String],
+    publishedAt: Option[Long],
+) derives JsonCodec

--- a/apps/api/infrastructure/src/test/scala/morecat/infrastructure/json/ArticleEventJsonCodecSpec.scala
+++ b/apps/api/infrastructure/src/test/scala/morecat/infrastructure/json/ArticleEventJsonCodecSpec.scala
@@ -7,7 +7,8 @@ object ArticleEventJsonCodecSpec extends ZIOSpecDefault:
 
   def spec = suite("ArticleEventJsonCodec")(
     test("round-trips ArticleDrafted without leaking JSON concerns into domain") {
-      val event = ArticleDrafted(Slug.applyUnsafe("hello-world"), Title.applyUnsafe("Hello"), "body")
+      val event =
+        ArticleDrafted(Slug.applyUnsafe("hello-world"), Title.applyUnsafe("Hello"), "body")
 
       assertTrue(ArticleEventJsonCodec.decode(ArticleEventJsonCodec.encode(event)) == Right(event))
     },

--- a/apps/api/infrastructure/src/test/scala/morecat/infrastructure/json/ArticleEventJsonCodecSpec.scala
+++ b/apps/api/infrastructure/src/test/scala/morecat/infrastructure/json/ArticleEventJsonCodecSpec.scala
@@ -34,4 +34,22 @@ object ArticleEventJsonCodecSpec extends ZIOSpecDefault:
 
       assertTrue(ArticleEventJsonCodec.decode(json).isLeft)
     },
+    test("rejects ArticleDrafted when a required field is missing") {
+      val json =
+        """{"eventType":"ArticleDrafted","schemaVersion":1,"slug":"hello-world","title":"Hello","publishedAt":null}"""
+
+      assertTrue(ArticleEventJsonCodec.decode(json).isLeft)
+    },
+    test("rejects ArticlePublished when publishedAt is missing") {
+      val json =
+        """{"eventType":"ArticlePublished","schemaVersion":1,"slug":null,"title":null,"body":null}"""
+
+      assertTrue(ArticleEventJsonCodec.decode(json).isLeft)
+    },
+    test("rejects ArticlePublished when draft-only fields are present") {
+      val json =
+        """{"eventType":"ArticlePublished","schemaVersion":1,"slug":"hello-world","title":null,"body":null,"publishedAt":999}"""
+
+      assertTrue(ArticleEventJsonCodec.decode(json).isLeft)
+    },
   )

--- a/apps/api/infrastructure/src/test/scala/morecat/infrastructure/json/ArticleEventJsonCodecSpec.scala
+++ b/apps/api/infrastructure/src/test/scala/morecat/infrastructure/json/ArticleEventJsonCodecSpec.scala
@@ -44,6 +44,14 @@ object ArticleEventJsonCodecSpec extends ZIOSpecDefault:
 
       assertTrue(ArticleEventJsonCodec.decode(json).isLeft)
     },
+    test("rejects unsupported eventType") {
+      val json =
+        """{"eventType":"ArticleArchived","schemaVersion":1}"""
+
+      assertTrue(
+        ArticleEventJsonCodec.decode(json) == Left("unsupported eventType: ArticleArchived")
+      )
+    },
     test("rejects invalid slug at the decode boundary") {
       val json =
         """{"eventType":"ArticleDrafted","schemaVersion":1,"slug":"../bad","title":"Hello","body":"body"}"""

--- a/apps/api/infrastructure/src/test/scala/morecat/infrastructure/json/ArticleEventJsonCodecSpec.scala
+++ b/apps/api/infrastructure/src/test/scala/morecat/infrastructure/json/ArticleEventJsonCodecSpec.scala
@@ -12,44 +12,83 @@ object ArticleEventJsonCodecSpec extends ZIOSpecDefault:
 
       assertTrue(ArticleEventJsonCodec.decode(ArticleEventJsonCodec.encode(event)) == Right(event))
     },
+    test("omits non-applicable fields when encoding ArticleDrafted") {
+      val event =
+        ArticleDrafted(Slug.applyUnsafe("hello-world"), Title.applyUnsafe("Hello"), "body")
+
+      assertTrue(!ArticleEventJsonCodec.encode(event).contains("publishedAt"))
+    },
     test("round-trips ArticlePublished") {
       val event = ArticlePublished(publishedAt = 999L)
 
       assertTrue(ArticleEventJsonCodec.decode(ArticleEventJsonCodec.encode(event)) == Right(event))
     },
+    test("omits draft-only fields when encoding ArticlePublished") {
+      val event = ArticlePublished(publishedAt = 999L)
+
+      assertTrue(
+        !ArticleEventJsonCodec.encode(event).contains("slug"),
+        !ArticleEventJsonCodec.encode(event).contains("title"),
+        !ArticleEventJsonCodec.encode(event).contains("body"),
+      )
+    },
     test("rejects unknown JSON fields") {
       val json =
-        """{"eventType":"ArticleDrafted","schemaVersion":1,"slug":"hello-world","title":"Hello","body":"body","publishedAt":null,"extra":true}"""
+        """{"eventType":"ArticleDrafted","schemaVersion":1,"slug":"hello-world","title":"Hello","body":"body","extra":true}"""
 
       assertTrue(ArticleEventJsonCodec.decode(json).isLeft)
     },
     test("rejects schemaVersion mismatch") {
       val json =
-        """{"eventType":"ArticleDrafted","schemaVersion":2,"slug":"hello-world","title":"Hello","body":"body","publishedAt":null}"""
+        """{"eventType":"ArticleDrafted","schemaVersion":2,"slug":"hello-world","title":"Hello","body":"body"}"""
 
       assertTrue(ArticleEventJsonCodec.decode(json).isLeft)
     },
     test("rejects invalid slug at the decode boundary") {
       val json =
-        """{"eventType":"ArticleDrafted","schemaVersion":1,"slug":"../bad","title":"Hello","body":"body","publishedAt":null}"""
+        """{"eventType":"ArticleDrafted","schemaVersion":1,"slug":"../bad","title":"Hello","body":"body"}"""
 
       assertTrue(ArticleEventJsonCodec.decode(json).isLeft)
     },
     test("rejects ArticleDrafted when a required field is missing") {
       val json =
-        """{"eventType":"ArticleDrafted","schemaVersion":1,"slug":"hello-world","title":"Hello","publishedAt":null}"""
+        """{"eventType":"ArticleDrafted","schemaVersion":1,"slug":"hello-world","title":"Hello"}"""
+
+      assertTrue(ArticleEventJsonCodec.decode(json).isLeft)
+    },
+    test("rejects ArticleDrafted when a required field is null") {
+      val json =
+        """{"eventType":"ArticleDrafted","schemaVersion":1,"slug":"hello-world","title":"Hello","body":null}"""
 
       assertTrue(ArticleEventJsonCodec.decode(json).isLeft)
     },
     test("rejects ArticlePublished when publishedAt is missing") {
       val json =
-        """{"eventType":"ArticlePublished","schemaVersion":1,"slug":null,"title":null,"body":null}"""
+        """{"eventType":"ArticlePublished","schemaVersion":1}"""
+
+      assertTrue(ArticleEventJsonCodec.decode(json).isLeft)
+    },
+    test("rejects ArticlePublished when publishedAt is null") {
+      val json =
+        """{"eventType":"ArticlePublished","schemaVersion":1,"publishedAt":null}"""
 
       assertTrue(ArticleEventJsonCodec.decode(json).isLeft)
     },
     test("rejects ArticlePublished when draft-only fields are present") {
       val json =
-        """{"eventType":"ArticlePublished","schemaVersion":1,"slug":"hello-world","title":null,"body":null,"publishedAt":999}"""
+        """{"eventType":"ArticlePublished","schemaVersion":1,"slug":"hello-world","publishedAt":999}"""
+
+      assertTrue(ArticleEventJsonCodec.decode(json).isLeft)
+    },
+    test("rejects ArticlePublished when draft-only fields are null") {
+      val json =
+        """{"eventType":"ArticlePublished","schemaVersion":1,"slug":null,"title":null,"body":null,"publishedAt":999}"""
+
+      assertTrue(ArticleEventJsonCodec.decode(json).isLeft)
+    },
+    test("rejects ArticleDrafted when publishedAt is null") {
+      val json =
+        """{"eventType":"ArticleDrafted","schemaVersion":1,"slug":"hello-world","title":"Hello","body":"body","publishedAt":null}"""
 
       assertTrue(ArticleEventJsonCodec.decode(json).isLeft)
     },

--- a/apps/api/infrastructure/src/test/scala/morecat/infrastructure/json/ArticleEventJsonCodecSpec.scala
+++ b/apps/api/infrastructure/src/test/scala/morecat/infrastructure/json/ArticleEventJsonCodecSpec.scala
@@ -1,0 +1,37 @@
+package morecat.infrastructure.json
+
+import morecat.domain.*
+import zio.test.*
+
+object ArticleEventJsonCodecSpec extends ZIOSpecDefault:
+
+  def spec = suite("ArticleEventJsonCodec")(
+    test("round-trips ArticleDrafted without leaking JSON concerns into domain") {
+      val event = ArticleDrafted(Slug.applyUnsafe("hello-world"), Title.applyUnsafe("Hello"), "body")
+
+      assertTrue(ArticleEventJsonCodec.decode(ArticleEventJsonCodec.encode(event)) == Right(event))
+    },
+    test("round-trips ArticlePublished") {
+      val event = ArticlePublished(publishedAt = 999L)
+
+      assertTrue(ArticleEventJsonCodec.decode(ArticleEventJsonCodec.encode(event)) == Right(event))
+    },
+    test("rejects unknown JSON fields") {
+      val json =
+        """{"eventType":"ArticleDrafted","schemaVersion":1,"slug":"hello-world","title":"Hello","body":"body","publishedAt":null,"extra":true}"""
+
+      assertTrue(ArticleEventJsonCodec.decode(json).isLeft)
+    },
+    test("rejects schemaVersion mismatch") {
+      val json =
+        """{"eventType":"ArticleDrafted","schemaVersion":2,"slug":"hello-world","title":"Hello","body":"body","publishedAt":null}"""
+
+      assertTrue(ArticleEventJsonCodec.decode(json).isLeft)
+    },
+    test("rejects invalid slug at the decode boundary") {
+      val json =
+        """{"eventType":"ArticleDrafted","schemaVersion":1,"slug":"../bad","title":"Hello","body":"body","publishedAt":null}"""
+
+      assertTrue(ArticleEventJsonCodec.decode(json).isLeft)
+    },
+  )

--- a/apps/api/project/plugins.sbt
+++ b/apps/api/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.5")

--- a/apps/api/project/plugins.sbt
+++ b/apps/api/project/plugins.sbt
@@ -1,1 +1,2 @@
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.5")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.4.4")


### PR DESCRIPTION
## Summary

- Add sbt-scoverage to the API build and generate a single aggregate coverage report.
- Upload the aggregate HTML report from CI as `api-scoverage-report`.
- Add tests for the remaining command-service and JSON codec branches, and enforce 100% statement and branch coverage.

## Notes

- This branch was created from the local `codex/api-application-skeleton` branch. That branch is not available as a GitHub base branch, so this draft PR currently targets `main` and includes the API skeleton commits plus the coverage commits.
- CI runs `scalafmtCheckAll clean` separately from `coverage test coverageAggregate` to avoid stale Scala 3 TASTy/instrumented class interactions in incremental builds.
- The aggregate report is generated under `apps/api/target/scala-*/scoverage-report/`.

## Validation

- `nix develop .#scala --command bash -c 'cd apps/api && sbt -batch -no-colors scalafmtCheckAll clean'`
- `nix develop .#scala --command bash -c 'cd apps/api && sbt -batch -no-colors coverage test coverageAggregate'`

Coverage result:

- Statement coverage: 100.00%
- Branch coverage: 100.00%
