### PR TITLE
[codex] Add API coverage report artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ permissions:
 
 jobs:
   api:
-    name: api (Scala) format, compile & test
+    name: api (Scala) format, compile, test & coverage
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -51,5 +51,13 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-sbt-
 
-      - name: Format check, compile & test (apps/api)
-        run: nix develop .#scala --command bash -c 'cd apps/api && sbt -batch -no-colors scalafmtCheckAll test'
+      - name: Format check, compile, test & coverage (apps/api)
+        run: nix develop .#scala --command bash -c 'cd apps/api && sbt -batch -no-colors scalafmtCheckAll coverage test coverageAggregate'
+
+      - name: Upload coverage report
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: api-scoverage-report
+          path: apps/api/target/scala-*/scoverage-report/**
+          if-no-files-found: error
+          retention-days: 14

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ permissions:
 
 jobs:
   api:
-    name: api (Scala) format, compile, test & coverage
+    name: api (Scala) format, compile & test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,9 @@ jobs:
             ${{ runner.os }}-sbt-
 
       - name: Format check, compile, test & coverage (apps/api)
-        run: nix develop .#scala --command bash -c 'cd apps/api && sbt -batch -no-colors scalafmtCheckAll coverage test coverageAggregate'
+        run: |
+          nix develop .#scala --command bash -c 'cd apps/api && sbt -batch -no-colors scalafmtCheckAll clean'
+          nix develop .#scala --command bash -c 'cd apps/api && sbt -batch -no-colors coverage test coverageAggregate'
 
       - name: Upload coverage report
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Format check, compile, test & coverage (apps/api)
         run: |
           nix develop .#scala --command bash -c 'cd apps/api && sbt -batch -no-colors scalafmtCheckAll clean'
-          nix develop .#scala --command bash -c 'cd apps/api && sbt -batch -no-colors coverage test coverageAggregate'
+          nix develop .#scala --command bash -c 'cd apps/api && sbt -batch -no-colors coverage domain/test application/test infrastructure/test coverageAggregate'
 
       - name: Upload coverage report
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@
 
 ## Build, Test, and Development Commands
 - 開発環境: ルートで `nix develop`（flake で JDK 25 / sbt / Node / Rust を固定。Scala 3.8 系は JDK 17+ 必須なので JDK は nix で揃える）。以降のコマンドは dev shell 内で実行する。
-- API(Scala): sbt ビルドルートは `apps/api`。`cd apps/api` してから `sbt compile` / `sbt test`。集約カバレッジ取得は `sbt coverage test coverageAggregate`（HTML は `target/scala-*/scoverage-report/`）。純粋ドメインだけは `sbt domain/test`。`api/run` 等は今後追加。
+- API(Scala): sbt ビルドルートは `apps/api`。`cd apps/api` してから `sbt compile` / `sbt test`。集約カバレッジ取得は `sbt clean` 後に `sbt coverage test coverageAggregate`（HTML は `target/scala-*/scoverage-report/`）。純粋ドメインだけは `sbt domain/test`。`api/run` 等は今後追加。
 - RMU(Rust): `cd apps/rmu` で `cargo build` / `cargo test`（実装はタスク3以降）。
 - UI: `apps/ui` で `pnpm install`、各 app で `pnpm dev` / `pnpm build` / `pnpm test` / `pnpm lint`。
 - 型生成: API の OpenAPI から `packages/api-client` を再生成（`pnpm gen:api`）。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@
 
 ## Build, Test, and Development Commands
 - 開発環境: ルートで `nix develop`（flake で JDK 25 / sbt / Node / Rust を固定。Scala 3.8 系は JDK 17+ 必須なので JDK は nix で揃える）。以降のコマンドは dev shell 内で実行する。
-- API(Scala): sbt ビルドルートは `apps/api`。`cd apps/api` してから `sbt compile` / `sbt test`。純粋ドメインだけは `sbt domain/test`。`api/run` 等は今後追加。
+- API(Scala): sbt ビルドルートは `apps/api`。`cd apps/api` してから `sbt compile` / `sbt test`。集約カバレッジ取得は `sbt coverage test coverageAggregate`（HTML は `target/scala-*/scoverage-report/`）。純粋ドメインだけは `sbt domain/test`。`api/run` 等は今後追加。
 - RMU(Rust): `cd apps/rmu` で `cargo build` / `cargo test`（実装はタスク3以降）。
 - UI: `apps/ui` で `pnpm install`、各 app で `pnpm dev` / `pnpm build` / `pnpm test` / `pnpm lint`。
 - 型生成: API の OpenAPI から `packages/api-client` を再生成（`pnpm gen:api`）。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@
 
 ## Build, Test, and Development Commands
 - 開発環境: ルートで `nix develop`（flake で JDK 25 / sbt / Node / Rust を固定。Scala 3.8 系は JDK 17+ 必須なので JDK は nix で揃える）。以降のコマンドは dev shell 内で実行する。
-- API(Scala): sbt ビルドルートは `apps/api`。`cd apps/api` してから `sbt compile` / `sbt test`。集約カバレッジ取得は `sbt clean` 後に `sbt coverage test coverageAggregate`（HTML は `target/scala-*/scoverage-report/`）。純粋ドメインだけは `sbt domain/test`。`api/run` 等は今後追加。
+- API(Scala): sbt ビルドルートは `apps/api`。`cd apps/api` してから `sbt compile` / `sbt test`。集約カバレッジ取得は `sbt clean` 後に `sbt coverage domain/test application/test infrastructure/test coverageAggregate`（HTML は `target/scala-*/scoverage-report/`）。純粋ドメインだけは `sbt domain/test`。`api/run` 等は今後追加。
 - RMU(Rust): `cd apps/rmu` で `cargo build` / `cargo test`（実装はタスク3以降）。
 - UI: `apps/ui` で `pnpm install`、各 app で `pnpm dev` / `pnpm build` / `pnpm test` / `pnpm lint`。
 - 型生成: API の OpenAPI から `packages/api-client` を再生成（`pnpm gen:api`）。

--- a/apps/api/application/src/main/scala/morecat/application/ArticleCommandService.scala
+++ b/apps/api/application/src/main/scala/morecat/application/ArticleCommandService.scala
@@ -30,20 +30,26 @@ enum PublishResult:
 final class ArticleCommandService(store: ArticleEventStore, clock: ServerClock):
 
   def createDraft(command: CreateDraftCommand): IO[CommandError, Unit] =
-    for
-      slug <- ZIO.fromEither(Slug.either(command.slug)).mapError(_ => CommandError.InvalidSlug)
-      title <- ZIO.fromEither(Title.either(command.title)).mapError(_ => CommandError.InvalidTitle)
-      event = ArticleDrafted(slug, title, command.body)
-      events <- store.load(command.articleId).mapError(toCommandError)
-      _ <-
-        if events.isEmpty then
-          store
-            .createDraft(command.articleId, event)
-            .mapError(toCommandError)
-            .catchAll(recoverCreateDraftConflict(command.articleId, event))
-        else if hasSameInitialDraft(events, event) then ZIO.unit
-        else ZIO.fail(CommandError.VersionConflict)
-    yield ()
+    ZIO
+      .fromEither(Slug.either(command.slug))
+      .mapError(_ => CommandError.InvalidSlug)
+      .flatMap { slug =>
+        ZIO
+          .fromEither(Title.either(command.title))
+          .mapError(_ => CommandError.InvalidTitle)
+          .flatMap { title =>
+            val event = ArticleDrafted(slug, title, command.body)
+            store.load(command.articleId).mapError(toCommandError).flatMap { events =>
+              if events.isEmpty then
+                store
+                  .createDraft(command.articleId, event)
+                  .mapError(toCommandError)
+                  .catchAll(recoverCreateDraftConflict(command.articleId, event))
+              else if hasSameInitialDraft(events, event) then ZIO.unit
+              else ZIO.fail(CommandError.VersionConflict)
+            }
+          }
+      }
 
   def publish(command: PublishArticleCommand): IO[CommandError, PublishResult] =
     for

--- a/apps/api/application/src/test/scala/morecat/application/ArticleCommandServiceSpec.scala
+++ b/apps/api/application/src/test/scala/morecat/application/ArticleCommandServiceSpec.scala
@@ -79,6 +79,17 @@ object ArticleCommandServiceSpec extends ZIOSpecDefault:
           fails(equalTo(CommandError.StoreUnavailable)),
         )
       },
+      test("maps store unavailability while creating to StoreUnavailable") {
+        val store =
+          RecordingStore(createDraftResult = ZIO.fail(EventStoreError.Unavailable("down")))
+        val service = ArticleCommandService(store, FixedClock(123L))
+
+        assertZIO(
+          service.createDraft(CreateDraftCommand(articleId, "hello-world", "Hello", "body")).exit
+        )(
+          fails(equalTo(CommandError.StoreUnavailable)),
+        )
+      },
       test("rejects invalid slug before touching the store") {
         val store = RecordingStore()
         val service = ArticleCommandService(store, FixedClock(123L))
@@ -87,6 +98,15 @@ object ArticleCommandServiceSpec extends ZIOSpecDefault:
             .createDraft(CreateDraftCommand(articleId, "../bad", "Hello", "body"))
             .exit
         yield assertTrue(exit == Exit.fail(CommandError.InvalidSlug), store.created.isEmpty)
+      },
+      test("rejects invalid title before touching the store") {
+        val store = RecordingStore()
+        val service = ArticleCommandService(store, FixedClock(123L))
+
+        for exit <- service
+            .createDraft(CreateDraftCommand(articleId, "hello-world", "", "body"))
+            .exit
+        yield assertTrue(exit == Exit.fail(CommandError.InvalidTitle), store.created.isEmpty)
       },
       test("is idempotent for the same articleId and same draft content") {
         val drafted =
@@ -123,6 +143,40 @@ object ArticleCommandServiceSpec extends ZIOSpecDefault:
           service.createDraft(CreateDraftCommand(articleId, "hello-world", "Changed", "body")).exit
         )(
           fails(equalTo(CommandError.VersionConflict)),
+        )
+      },
+      test("keeps slug conflicts when reload does not show the requested draft") {
+        val otherDraft =
+          ArticleDrafted(Slug.applyUnsafe("hello-world"), Title.applyUnsafe("Other"), "body")
+        val store = RecordingStore(
+          loadResults = List(
+            ZIO.succeed(Chunk.empty),
+            ZIO.succeed(Chunk(SequencedArticleEvent(seq = 1L, event = otherDraft))),
+          ),
+          createDraftResult = ZIO.fail(EventStoreError.SlugAlreadyReserved),
+        )
+        val service = ArticleCommandService(store, FixedClock(123L))
+
+        assertZIO(
+          service.createDraft(CreateDraftCommand(articleId, "hello-world", "Hello", "body")).exit
+        )(
+          fails(equalTo(CommandError.SlugConflict)),
+        )
+      },
+      test("maps reload unavailability after create conflict to StoreUnavailable") {
+        val store = RecordingStore(
+          loadResults = List(
+            ZIO.succeed(Chunk.empty),
+            ZIO.fail(EventStoreError.Unavailable("down")),
+          ),
+          createDraftResult = ZIO.fail(EventStoreError.VersionConflict),
+        )
+        val service = ArticleCommandService(store, FixedClock(123L))
+
+        assertZIO(
+          service.createDraft(CreateDraftCommand(articleId, "hello-world", "Hello", "body")).exit
+        )(
+          fails(equalTo(CommandError.StoreUnavailable)),
         )
       },
       test("treats create conflict as idempotent when reload shows the same draft") {
@@ -179,6 +233,22 @@ object ArticleCommandServiceSpec extends ZIOSpecDefault:
 
         assertZIO(service.publish(PublishArticleCommand(articleId, expectedVersion = 0L)).exit)(
           fails(equalTo(CommandError.VersionConflict)),
+        )
+      },
+      test("maps append unavailability to StoreUnavailable") {
+        val drafted = SequencedArticleEvent(
+          seq = 1L,
+          event =
+            ArticleDrafted(Slug.applyUnsafe("hello-world"), Title.applyUnsafe("Hello"), "body"),
+        )
+        val store = RecordingStore(
+          initialEvents = Chunk(drafted),
+          appendResult = ZIO.fail(EventStoreError.Unavailable("down")),
+        )
+        val service = ArticleCommandService(store, FixedClock(999L))
+
+        assertZIO(service.publish(PublishArticleCommand(articleId, expectedVersion = 1L)).exit)(
+          fails(equalTo(CommandError.StoreUnavailable)),
         )
       },
       test("maps store unavailability while loading to StoreUnavailable") {
@@ -253,6 +323,44 @@ object ArticleCommandServiceSpec extends ZIOSpecDefault:
 
         assertZIO(service.publish(PublishArticleCommand(articleId, expectedVersion = 1L)))(
           equalTo(PublishResult.AlreadyPublished),
+        )
+      },
+      test("keeps append conflicts when reload does not show a published article") {
+        val drafted = SequencedArticleEvent(
+          seq = 1L,
+          event =
+            ArticleDrafted(Slug.applyUnsafe("hello-world"), Title.applyUnsafe("Hello"), "body"),
+        )
+        val store = RecordingStore(
+          loadResults = List(
+            ZIO.succeed(Chunk(drafted)),
+            ZIO.succeed(Chunk(drafted)),
+          ),
+          appendResult = ZIO.fail(EventStoreError.VersionConflict),
+        )
+        val service = ArticleCommandService(store, FixedClock(999L))
+
+        assertZIO(service.publish(PublishArticleCommand(articleId, expectedVersion = 1L)).exit)(
+          fails(equalTo(CommandError.VersionConflict)),
+        )
+      },
+      test("maps reload unavailability after append conflict to StoreUnavailable") {
+        val drafted = SequencedArticleEvent(
+          seq = 1L,
+          event =
+            ArticleDrafted(Slug.applyUnsafe("hello-world"), Title.applyUnsafe("Hello"), "body"),
+        )
+        val store = RecordingStore(
+          loadResults = List(
+            ZIO.succeed(Chunk(drafted)),
+            ZIO.fail(EventStoreError.Unavailable("down")),
+          ),
+          appendResult = ZIO.fail(EventStoreError.VersionConflict),
+        )
+        val service = ArticleCommandService(store, FixedClock(999L))
+
+        assertZIO(service.publish(PublishArticleCommand(articleId, expectedVersion = 1L)).exit)(
+          fails(equalTo(CommandError.StoreUnavailable)),
         )
       },
     ),

--- a/apps/api/application/src/test/scala/morecat/application/ArticleCommandServiceSpec.scala
+++ b/apps/api/application/src/test/scala/morecat/application/ArticleCommandServiceSpec.scala
@@ -17,18 +17,22 @@ object ArticleCommandServiceSpec extends ZIOSpecDefault:
   ) extends ArticleEventStore:
     var created: List[(ArticleId, ArticleDrafted)] = Nil
     var appended: List[(ArticleId, Long, ArticleEvent)] = Nil
+    var loaded: List[ArticleId] = Nil
     private var remainingLoads = loadResults
     def createDraft(articleId: ArticleId, event: ArticleDrafted): IO[EventStoreError, Unit] =
       createDraftResult *> ZIO.succeed {
         created = created :+ (articleId, event)
       }
     def load(articleId: ArticleId): IO[EventStoreError, Chunk[SequencedArticleEvent]] =
-      remainingLoads match
-        case next :: rest =>
-          remainingLoads = rest
-          next
-        case Nil =>
-          ZIO.succeed(initialEvents)
+      ZIO.succeed {
+        loaded = loaded :+ articleId
+      } *>
+        (remainingLoads match
+          case next :: rest =>
+            remainingLoads = rest
+            next
+          case Nil =>
+            ZIO.succeed(initialEvents))
     def append(
       articleId: ArticleId,
       expectedVersion: Long,
@@ -97,7 +101,11 @@ object ArticleCommandServiceSpec extends ZIOSpecDefault:
         for exit <- service
             .createDraft(CreateDraftCommand(articleId, "../bad", "Hello", "body"))
             .exit
-        yield assertTrue(exit == Exit.fail(CommandError.InvalidSlug), store.created.isEmpty)
+        yield assertTrue(
+          exit == Exit.fail(CommandError.InvalidSlug),
+          store.loaded.isEmpty,
+          store.created.isEmpty,
+        )
       },
       test("rejects invalid title before touching the store") {
         val store = RecordingStore()
@@ -106,7 +114,11 @@ object ArticleCommandServiceSpec extends ZIOSpecDefault:
         for exit <- service
             .createDraft(CreateDraftCommand(articleId, "hello-world", "", "body"))
             .exit
-        yield assertTrue(exit == Exit.fail(CommandError.InvalidTitle), store.created.isEmpty)
+        yield assertTrue(
+          exit == Exit.fail(CommandError.InvalidTitle),
+          store.loaded.isEmpty,
+          store.created.isEmpty,
+        )
       },
       test("is idempotent for the same articleId and same draft content") {
         val drafted =
@@ -219,7 +231,7 @@ object ArticleCommandServiceSpec extends ZIOSpecDefault:
           store.appended == List((articleId, 1L, ArticlePublished(publishedAt = 999L))),
         )
       },
-      test("maps expected version conflicts without hiding them") {
+      test("rejects stale expected versions before appending") {
         val drafted = SequencedArticleEvent(
           seq = 1L,
           event =
@@ -231,8 +243,10 @@ object ArticleCommandServiceSpec extends ZIOSpecDefault:
         )
         val service = ArticleCommandService(store, FixedClock(999L))
 
-        assertZIO(service.publish(PublishArticleCommand(articleId, expectedVersion = 0L)).exit)(
-          fails(equalTo(CommandError.VersionConflict)),
+        for exit <- service.publish(PublishArticleCommand(articleId, expectedVersion = 0L)).exit
+        yield assertTrue(
+          exit == Exit.fail(CommandError.VersionConflict),
+          store.appended.isEmpty,
         )
       },
       test("maps append unavailability to StoreUnavailable") {

--- a/apps/api/build.sbt
+++ b/apps/api/build.sbt
@@ -18,6 +18,9 @@ ThisBuild / scalacOptions ++= Seq(
 )
 
 ThisBuild / coverageEnabled := false
+ThisBuild / coverageMinimumStmtTotal := 100
+ThisBuild / coverageMinimumBranchTotal := 100
+ThisBuild / coverageFailOnMinimum := true
 
 lazy val root = project
   .in(file("."))

--- a/apps/api/build.sbt
+++ b/apps/api/build.sbt
@@ -17,6 +17,16 @@ ThisBuild / scalacOptions ++= Seq(
   "-Wunused:all",
 )
 
+ThisBuild / coverageEnabled := false
+
+lazy val root = project
+  .in(file("."))
+  .aggregate(domain, application, infrastructure)
+  .settings(
+    name := "morecat-api",
+    publish / skip := true,
+  )
+
 // 純粋ドメイン: Article イベント ADT・値オブジェクト(Iron)・projection fold。
 // IO や wire フォーマット(JSON 等)への依存を載せないことをビルドで強制する。
 // JSON codec は infrastructure 層の関心事。RMU(Rust) とはコードを共有せず、

--- a/apps/api/infrastructure/src/test/scala/morecat/infrastructure/json/ArticleEventJsonCodecSpec.scala
+++ b/apps/api/infrastructure/src/test/scala/morecat/infrastructure/json/ArticleEventJsonCodecSpec.scala
@@ -44,6 +44,14 @@ object ArticleEventJsonCodecSpec extends ZIOSpecDefault:
 
       assertTrue(ArticleEventJsonCodec.decode(json).isLeft)
     },
+    test("rejects unsupported eventType") {
+      val json =
+        """{"eventType":"ArticleArchived","schemaVersion":1}"""
+
+      assertTrue(
+        ArticleEventJsonCodec.decode(json) == Left("unsupported eventType: ArticleArchived")
+      )
+    },
     test("rejects invalid slug at the decode boundary") {
       val json =
         """{"eventType":"ArticleDrafted","schemaVersion":1,"slug":"../bad","title":"Hello","body":"body"}"""

--- a/apps/api/project/plugins.sbt
+++ b/apps/api/project/plugins.sbt
@@ -1,1 +1,2 @@
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.5")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.4.4")


### PR DESCRIPTION
## Summary

- Add sbt-scoverage to the API build and generate a single aggregate coverage report.
- Upload the aggregate HTML report from CI as `api-scoverage-report`.
- Add tests for the remaining command-service and JSON codec branches, and enforce 100% statement and branch coverage.

## Notes

- This branch was recreated from the latest `main` (`72756f01ddde3fff3ef80e3427280081d7d43a24`) so the PR contains only the coverage-report changes.
- CI runs `scalafmtCheckAll clean` separately from `coverage test coverageAggregate` to avoid stale Scala 3 TASTy/instrumented class interactions in incremental builds.
- The aggregate report is generated under `apps/api/target/scala-*/scoverage-report/`.

## Validation

- `nix develop .#scala --command bash -c 'cd apps/api && sbt -batch -no-colors scalafmtCheckAll clean'`
- `nix develop .#scala --command bash -c 'cd apps/api && sbt -batch -no-colors coverage test coverageAggregate'`

Coverage result:

- Statement coverage: 100.00%
- Branch coverage: 100.00%
