### PR TITLE
[codex] Validate article drafts in domain

### DIFF
--- a/apps/api/application/src/main/scala/morecat/application/ArticleCommandService.scala
+++ b/apps/api/application/src/main/scala/morecat/application/ArticleCommandService.scala
@@ -16,8 +16,7 @@ final case class PublishArticleCommand(
 )
 
 enum CommandError:
-  case InvalidSlug
-  case InvalidTitle
+  case InvalidDraft(errors: Chunk[ArticleDrafted.ValidationError])
   case SlugConflict
   case VersionConflict
   case ArticleNotFound
@@ -31,24 +30,18 @@ final class ArticleCommandService(store: ArticleEventStore, clock: ServerClock):
 
   def createDraft(command: CreateDraftCommand): IO[CommandError, Unit] =
     ZIO
-      .fromEither(Slug.either(command.slug))
-      .mapError(_ => CommandError.InvalidSlug)
-      .flatMap { slug =>
-        ZIO
-          .fromEither(Title.either(command.title))
-          .mapError(_ => CommandError.InvalidTitle)
-          .flatMap { title =>
-            val event = ArticleDrafted(slug, title, command.body)
-            store.load(command.articleId).mapError(toCommandError).flatMap { events =>
-              if events.isEmpty then
-                store
-                  .createDraft(command.articleId, event)
-                  .mapError(toCommandError)
-                  .catchAll(recoverCreateDraftConflict(command.articleId, event))
-              else if hasSameInitialDraft(events, event) then ZIO.unit
-              else ZIO.fail(CommandError.VersionConflict)
-            }
-          }
+      .fromEither(ArticleDrafted.either(command.slug, command.title, command.body))
+      .mapError(errors => CommandError.InvalidDraft(Chunk.fromIterable(errors)))
+      .flatMap { event =>
+        store.load(command.articleId).mapError(toCommandError).flatMap { events =>
+          if events.isEmpty then
+            store
+              .createDraft(command.articleId, event)
+              .mapError(toCommandError)
+              .catchAll(recoverCreateDraftConflict(command.articleId, event))
+          else if hasSameInitialDraft(events, event) then ZIO.unit
+          else ZIO.fail(CommandError.VersionConflict)
+        }
       }
 
   def publish(command: PublishArticleCommand): IO[CommandError, PublishResult] =

--- a/apps/api/application/src/test/scala/morecat/application/ArticleCommandServiceSpec.scala
+++ b/apps/api/application/src/test/scala/morecat/application/ArticleCommandServiceSpec.scala
@@ -1,6 +1,6 @@
 package morecat.application
 
-import morecat.domain.*
+import _root_.morecat.domain.*
 import zio.*
 import zio.test.Assertion.*
 import zio.test.*
@@ -8,6 +8,13 @@ import zio.test.*
 object ArticleCommandServiceSpec extends ZIOSpecDefault:
 
   private val articleId = ArticleId.fromString("018f4edc-1f5a-7c4b-aef9-000000000001")
+
+  private def articleDrafted(
+    slug: String = "hello-world",
+    title: String = "Hello",
+    body: String = "body",
+  ): ArticleDrafted =
+    ArticleDrafted.applyUnsafe(slug, title, body)
 
   private final class RecordingStore(
     initialEvents: Chunk[SequencedArticleEvent] = Chunk.empty,
@@ -46,6 +53,24 @@ object ArticleCommandServiceSpec extends ZIOSpecDefault:
     def nowMillis: UIO[Long] = ZIO.succeed(value)
 
   def spec = suite("ArticleCommandService")(
+    suite("domain constructors used by commands")(
+      test("ArticleBody applyUnsafe returns valid content") {
+        assertTrue(ArticleBody.applyUnsafe("body").value == "body")
+      },
+      test("ArticleBody applyUnsafe throws for oversized content") {
+        val body = "x" * (ArticleBody.MaxBytes + 1)
+
+        assertZIO(ZIO.attempt(ArticleBody.applyUnsafe(body)).exit)(fails(anything))
+      },
+      test("ArticleDrafted applyUnsafe throws for invalid content") {
+        assertZIO(ZIO.attempt(ArticleDrafted.applyUnsafe("../bad", "", "body")).exit)(
+          fails(anything)
+        )
+      },
+      test("ArticleId exposes its opaque string value") {
+        assertTrue(articleId.asString == "018f4edc-1f5a-7c4b-aef9-000000000001")
+      },
+    ),
     suite("createDraft")(
       test("creates an ArticleDrafted event with validated slug and title") {
         val store = RecordingStore()
@@ -56,7 +81,7 @@ object ArticleCommandServiceSpec extends ZIOSpecDefault:
           store.created == List(
             (
               articleId,
-              ArticleDrafted(Slug.applyUnsafe("hello-world"), Title.applyUnsafe("Hello"), "body")
+              articleDrafted()
             ),
           ),
         )
@@ -102,7 +127,9 @@ object ArticleCommandServiceSpec extends ZIOSpecDefault:
             .createDraft(CreateDraftCommand(articleId, "../bad", "Hello", "body"))
             .exit
         yield assertTrue(
-          exit == Exit.fail(CommandError.InvalidSlug),
+          exit == Exit.fail(
+            CommandError.InvalidDraft(Chunk(ArticleDrafted.ValidationError.InvalidSlug))
+          ),
           store.loaded.isEmpty,
           store.created.isEmpty,
         )
@@ -115,14 +142,68 @@ object ArticleCommandServiceSpec extends ZIOSpecDefault:
             .createDraft(CreateDraftCommand(articleId, "hello-world", "", "body"))
             .exit
         yield assertTrue(
-          exit == Exit.fail(CommandError.InvalidTitle),
+          exit == Exit.fail(
+            CommandError.InvalidDraft(Chunk(ArticleDrafted.ValidationError.InvalidTitle))
+          ),
           store.loaded.isEmpty,
           store.created.isEmpty,
         )
       },
+      test("rejects body content larger than the domain limit before touching the store") {
+        val store = RecordingStore()
+        val service = ArticleCommandService(store, FixedClock(123L))
+        val oversizedBody = "x" * (ArticleBody.MaxBytes + 1)
+
+        for exit <- service
+            .createDraft(CreateDraftCommand(articleId, "hello-world", "Hello", oversizedBody))
+            .exit
+        yield assertTrue(
+          exit == Exit.fail(
+            CommandError.InvalidDraft(Chunk(ArticleDrafted.ValidationError.BodyTooLarge))
+          ),
+          store.loaded.isEmpty,
+          store.created.isEmpty,
+        )
+      },
+      test("collects every draft validation error before touching the store") {
+        val store = RecordingStore()
+        val service = ArticleCommandService(store, FixedClock(123L))
+        val oversizedBody = "x" * (ArticleBody.MaxBytes + 1)
+
+        for exit <- service
+            .createDraft(CreateDraftCommand(articleId, "../bad", "", oversizedBody))
+            .exit
+        yield assertTrue(
+          exit == Exit.fail(
+            CommandError.InvalidDraft(
+              Chunk(
+                ArticleDrafted.ValidationError.InvalidSlug,
+                ArticleDrafted.ValidationError.InvalidTitle,
+                ArticleDrafted.ValidationError.BodyTooLarge,
+              ),
+            )
+          ),
+          store.loaded.isEmpty,
+          store.created.isEmpty,
+        )
+      },
+      test("accepts body content exactly at the domain limit") {
+        val store = RecordingStore()
+        val service = ArticleCommandService(store, FixedClock(123L))
+        val body = "x" * ArticleBody.MaxBytes
+
+        for _ <- service.createDraft(CreateDraftCommand(articleId, "hello-world", "Hello", body))
+        yield assertTrue(
+          store.created == List(
+            (
+              articleId,
+              articleDrafted(body = body),
+            ),
+          ),
+        )
+      },
       test("is idempotent for the same articleId and same draft content") {
-        val drafted =
-          ArticleDrafted(Slug.applyUnsafe("hello-world"), Title.applyUnsafe("Hello"), "body")
+        val drafted = articleDrafted()
         val store =
           RecordingStore(initialEvents = Chunk(SequencedArticleEvent(seq = 1L, event = drafted)))
         val service = ArticleCommandService(store, FixedClock(123L))
@@ -131,8 +212,7 @@ object ArticleCommandServiceSpec extends ZIOSpecDefault:
         yield assertTrue(store.created.isEmpty)
       },
       test("is idempotent for the same initial draft even after later events") {
-        val drafted =
-          ArticleDrafted(Slug.applyUnsafe("hello-world"), Title.applyUnsafe("Hello"), "body")
+        val drafted = articleDrafted()
         val store = RecordingStore(
           initialEvents = Chunk(
             SequencedArticleEvent(seq = 1L, event = drafted),
@@ -145,8 +225,7 @@ object ArticleCommandServiceSpec extends ZIOSpecDefault:
         yield assertTrue(store.created.isEmpty)
       },
       test("rejects the same articleId with different draft content") {
-        val drafted =
-          ArticleDrafted(Slug.applyUnsafe("hello-world"), Title.applyUnsafe("Hello"), "body")
+        val drafted = articleDrafted()
         val store =
           RecordingStore(initialEvents = Chunk(SequencedArticleEvent(seq = 1L, event = drafted)))
         val service = ArticleCommandService(store, FixedClock(123L))
@@ -158,8 +237,7 @@ object ArticleCommandServiceSpec extends ZIOSpecDefault:
         )
       },
       test("keeps slug conflicts when reload does not show the requested draft") {
-        val otherDraft =
-          ArticleDrafted(Slug.applyUnsafe("hello-world"), Title.applyUnsafe("Other"), "body")
+        val otherDraft = articleDrafted(title = "Other")
         val store = RecordingStore(
           loadResults = List(
             ZIO.succeed(Chunk.empty),
@@ -192,8 +270,7 @@ object ArticleCommandServiceSpec extends ZIOSpecDefault:
         )
       },
       test("treats create conflict as idempotent when reload shows the same draft") {
-        val drafted =
-          ArticleDrafted(Slug.applyUnsafe("hello-world"), Title.applyUnsafe("Hello"), "body")
+        val drafted = articleDrafted()
         val store = RecordingStore(
           loadResults = List(
             ZIO.succeed(Chunk.empty),
@@ -219,8 +296,7 @@ object ArticleCommandServiceSpec extends ZIOSpecDefault:
       test("appends ArticlePublished with server time and expected version") {
         val drafted = SequencedArticleEvent(
           seq = 1L,
-          event =
-            ArticleDrafted(Slug.applyUnsafe("hello-world"), Title.applyUnsafe("Hello"), "body"),
+          event = articleDrafted(),
         )
         val store = RecordingStore(initialEvents = Chunk(drafted))
         val service = ArticleCommandService(store, FixedClock(999L))
@@ -234,8 +310,7 @@ object ArticleCommandServiceSpec extends ZIOSpecDefault:
       test("rejects stale expected versions before appending") {
         val drafted = SequencedArticleEvent(
           seq = 1L,
-          event =
-            ArticleDrafted(Slug.applyUnsafe("hello-world"), Title.applyUnsafe("Hello"), "body"),
+          event = articleDrafted(),
         )
         val store = RecordingStore(
           initialEvents = Chunk(drafted),
@@ -252,8 +327,7 @@ object ArticleCommandServiceSpec extends ZIOSpecDefault:
       test("maps append unavailability to StoreUnavailable") {
         val drafted = SequencedArticleEvent(
           seq = 1L,
-          event =
-            ArticleDrafted(Slug.applyUnsafe("hello-world"), Title.applyUnsafe("Hello"), "body"),
+          event = articleDrafted(),
         )
         val store = RecordingStore(
           initialEvents = Chunk(drafted),
@@ -278,7 +352,7 @@ object ArticleCommandServiceSpec extends ZIOSpecDefault:
         val events = Chunk(
           SequencedArticleEvent(
             1L,
-            ArticleDrafted(Slug.applyUnsafe("hello-world"), Title.applyUnsafe("Hello"), "body")
+            articleDrafted()
           ),
           SequencedArticleEvent(2L, ArticlePublished(publishedAt = 999L)),
         )
@@ -292,7 +366,7 @@ object ArticleCommandServiceSpec extends ZIOSpecDefault:
         val events = Chunk(
           SequencedArticleEvent(
             1L,
-            ArticleDrafted(Slug.applyUnsafe("hello-world"), Title.applyUnsafe("Hello"), "body")
+            articleDrafted()
           ),
           SequencedArticleEvent(2L, ArticlePublished(publishedAt = 999L)),
         )
@@ -308,7 +382,7 @@ object ArticleCommandServiceSpec extends ZIOSpecDefault:
         val events = Chunk(
           SequencedArticleEvent(
             1L,
-            ArticleDrafted(Slug.applyUnsafe("hello-world"), Title.applyUnsafe("Hello"), "body")
+            articleDrafted()
           ),
           SequencedArticleEvent(2L, ArticlePublished(publishedAt = 999L)),
         )
@@ -321,8 +395,7 @@ object ArticleCommandServiceSpec extends ZIOSpecDefault:
       test("returns AlreadyPublished when append conflict reload shows the publish succeeded") {
         val drafted = SequencedArticleEvent(
           seq = 1L,
-          event =
-            ArticleDrafted(Slug.applyUnsafe("hello-world"), Title.applyUnsafe("Hello"), "body"),
+          event = articleDrafted(),
         )
         val published =
           SequencedArticleEvent(seq = 2L, event = ArticlePublished(publishedAt = 999L))
@@ -342,8 +415,7 @@ object ArticleCommandServiceSpec extends ZIOSpecDefault:
       test("keeps append conflicts when reload does not show a published article") {
         val drafted = SequencedArticleEvent(
           seq = 1L,
-          event =
-            ArticleDrafted(Slug.applyUnsafe("hello-world"), Title.applyUnsafe("Hello"), "body"),
+          event = articleDrafted(),
         )
         val store = RecordingStore(
           loadResults = List(
@@ -361,8 +433,7 @@ object ArticleCommandServiceSpec extends ZIOSpecDefault:
       test("maps reload unavailability after append conflict to StoreUnavailable") {
         val drafted = SequencedArticleEvent(
           seq = 1L,
-          event =
-            ArticleDrafted(Slug.applyUnsafe("hello-world"), Title.applyUnsafe("Hello"), "body"),
+          event = articleDrafted(),
         )
         val store = RecordingStore(
           loadResults = List(

--- a/apps/api/application/src/test/scala/morecat/application/PublishedArticleServiceSpec.scala
+++ b/apps/api/application/src/test/scala/morecat/application/PublishedArticleServiceSpec.scala
@@ -1,6 +1,6 @@
 package morecat.application
 
-import morecat.domain.*
+import _root_.morecat.domain.*
 import zio.*
 import zio.test.Assertion.*
 import zio.test.*

--- a/apps/api/domain/src/main/scala/morecat/domain/ArticleBody.scala
+++ b/apps/api/domain/src/main/scala/morecat/domain/ArticleBody.scala
@@ -1,0 +1,25 @@
+package morecat.domain
+
+import java.nio.charset.StandardCharsets
+
+/** Markdown 本文。サイズ上限は UTF-8 bytes で判定する。 */
+opaque type ArticleBody = String
+
+object ArticleBody:
+  val MaxBytes: Int = 256 * 1024
+
+  enum Error:
+    case TooLarge
+
+  def either(value: String): Either[Error, ArticleBody] =
+    Either.cond(byteSize(value) <= MaxBytes, value, Error.TooLarge)
+
+  def applyUnsafe(value: String): ArticleBody =
+    either(value).fold(error => throw IllegalArgumentException(error.toString), identity)
+
+  def fromStoredEvent(value: String): ArticleBody = value
+
+  extension (body: ArticleBody) def value: String = body
+
+  private def byteSize(value: String): Int =
+    value.getBytes(StandardCharsets.UTF_8).length

--- a/apps/api/domain/src/main/scala/morecat/domain/ArticleEvent.scala
+++ b/apps/api/domain/src/main/scala/morecat/domain/ArticleEvent.scala
@@ -11,15 +11,67 @@ sealed trait ArticleEvent:
   def schemaVersion: Int
 
 /** 下書き作成（初期 slug/title/body）。tags は slice2 以降。 */
-final case class ArticleDrafted(
+final case class ArticleDrafted private (
   slug: Slug,
   title: Title,
-  body: String,
+  body: ArticleBody,
 ) extends ArticleEvent:
   val schemaVersion: Int = ArticleDrafted.CurrentSchemaVersion
 
 object ArticleDrafted:
   val CurrentSchemaVersion: Int = 1
+
+  enum ValidationError:
+    case InvalidSlug
+    case InvalidTitle
+    case BodyTooLarge
+
+  def either(
+    slug: String,
+    title: String,
+    body: String,
+  ): Either[Seq[ValidationError], ArticleDrafted] =
+    val refinedSlug = Slug.either(slug).left.map(_ => ValidationError.InvalidSlug)
+    val refinedTitle = Title.either(title).left.map(_ => ValidationError.InvalidTitle)
+    val refinedBody = ArticleBody.either(body).left.map(_ => ValidationError.BodyTooLarge)
+    val errors =
+      List(refinedSlug.left.toOption, refinedTitle.left.toOption, refinedBody.left.toOption).flatten
+
+    if errors.nonEmpty then Left(errors)
+    else
+      Right(
+        ArticleDrafted(
+          refinedSlug.toOption.get,
+          refinedTitle.toOption.get,
+          refinedBody.toOption.get
+        )
+      )
+
+  def fromStoredEvent(
+    slug: String,
+    title: String,
+    body: String,
+  ): Either[Seq[ValidationError], ArticleDrafted] =
+    val refinedSlug = Slug.either(slug).left.map(_ => ValidationError.InvalidSlug)
+    val refinedTitle = Title.either(title).left.map(_ => ValidationError.InvalidTitle)
+    val errors =
+      List(refinedSlug.left.toOption, refinedTitle.left.toOption).flatten
+
+    if errors.nonEmpty then Left(errors)
+    else
+      Right(
+        ArticleDrafted(
+          refinedSlug.toOption.get,
+          refinedTitle.toOption.get,
+          ArticleBody.fromStoredEvent(body)
+        )
+      )
+
+  def applyUnsafe(slug: String, title: String, body: String): ArticleDrafted =
+    either(slug, title, body).fold(
+      errors => throw IllegalArgumentException(errors.mkString(",")),
+      identity,
+    )
 
 /** 公開。publishedAt はサーバ時刻（epoch millis）。 */
 final case class ArticlePublished(

--- a/apps/api/domain/src/test/scala/morecat/domain/DomainSpec.scala
+++ b/apps/api/domain/src/test/scala/morecat/domain/DomainSpec.scala
@@ -1,5 +1,7 @@
 package morecat.domain
 
+import zio.*
+import zio.test.Assertion.*
 import zio.test.*
 
 object DomainSpec extends ZIOSpecDefault:
@@ -43,6 +45,31 @@ object DomainSpec extends ZIOSpecDefault:
         }
       },
     ),
+    suite("ArticleBody")(
+      test("accepts body content exactly at the byte limit") {
+        val body = "x" * ArticleBody.MaxBytes
+
+        assertTrue(ArticleBody.either(body).map(_.value) == Right(body))
+      },
+      test("rejects body content larger than the byte limit") {
+        val body = "x" * (ArticleBody.MaxBytes + 1)
+
+        assertTrue(ArticleBody.either(body) == Left(ArticleBody.Error.TooLarge))
+      },
+      test("uses UTF-8 bytes rather than character count") {
+        val body = "あ" * ((ArticleBody.MaxBytes / 3) + 1)
+
+        assertTrue(ArticleBody.either(body) == Left(ArticleBody.Error.TooLarge))
+      },
+      test("applyUnsafe returns the body value for valid content") {
+        assertTrue(ArticleBody.applyUnsafe("body").value == "body")
+      },
+      test("applyUnsafe throws for oversized content") {
+        val body = "x" * (ArticleBody.MaxBytes + 1)
+
+        assertZIO(ZIO.attempt(ArticleBody.applyUnsafe(body)).exit)(fails(anything))
+      },
+    ),
     suite("ArticleId")(
       test("fromString / asString round-trips any string") {
         check(Gen.string) { s =>
@@ -54,11 +81,37 @@ object DomainSpec extends ZIOSpecDefault:
       // schemaVersion は wire 契約の核。現行版を lock して不用意な変更を検出する。
       test("schemaVersion is fixed to the current version (1)") {
         assertTrue(
-          ArticleDrafted(Slug.applyUnsafe("a"), Title.applyUnsafe("t"), "body").schemaVersion ==
+          ArticleDrafted.applyUnsafe("a", "t", "body").schemaVersion ==
             ArticleDrafted.CurrentSchemaVersion,
           ArticlePublished(publishedAt = 0L).schemaVersion == ArticlePublished.CurrentSchemaVersion,
           ArticleDrafted.CurrentSchemaVersion == 1,
           ArticlePublished.CurrentSchemaVersion == 1,
+        )
+      },
+      test("ArticleDrafted smart constructor collects every validation error") {
+        val oversizedBody = "x" * (ArticleBody.MaxBytes + 1)
+
+        assertTrue(
+          ArticleDrafted.either("../bad", "", oversizedBody) == Left(
+            Seq(
+              ArticleDrafted.ValidationError.InvalidSlug,
+              ArticleDrafted.ValidationError.InvalidTitle,
+              ArticleDrafted.ValidationError.BodyTooLarge,
+            )
+          )
+        )
+      },
+      test("ArticleDrafted applyUnsafe throws for invalid draft content") {
+        assertZIO(ZIO.attempt(ArticleDrafted.applyUnsafe("../bad", "", "body")).exit)(
+          fails(anything)
+        )
+      },
+      test("ArticleDrafted stored-event constructor preserves oversized historical body") {
+        val body = "x" * (ArticleBody.MaxBytes + 1)
+
+        assertTrue(
+          ArticleDrafted.fromStoredEvent("hello-world", "Hello", body).map(_.body.value) ==
+            Right(body)
         )
       },
     ),

--- a/apps/api/infrastructure/src/main/scala/morecat/infrastructure/json/ArticleEventJsonCodec.scala
+++ b/apps/api/infrastructure/src/main/scala/morecat/infrastructure/json/ArticleEventJsonCodec.scala
@@ -11,9 +11,9 @@ object ArticleEventJsonCodec:
         WireArticleDrafted(
           eventType = "ArticleDrafted",
           schemaVersion = ArticleDrafted.CurrentSchemaVersion,
-          slug = slug,
-          title = title,
-          body = body,
+          slug = slug.toString,
+          title = title.toString,
+          body = body.value,
         ).toJson
       case ArticlePublished(publishedAt) =>
         WireArticlePublished(
@@ -37,9 +37,11 @@ object ArticleEventJsonCodec:
   private def toDomain(wire: WireArticleDrafted): Either[String, ArticleEvent] =
     for
       _ <- requireSchemaVersion(wire.schemaVersion, ArticleDrafted.CurrentSchemaVersion)
-      slug <- Slug.either(wire.slug)
-      title <- Title.either(wire.title)
-    yield ArticleDrafted(slug, title, wire.body)
+      event <- ArticleDrafted
+        .fromStoredEvent(wire.slug, wire.title, wire.body)
+        .left
+        .map(_.mkString(","))
+    yield event
 
   private def toDomain(wire: WireArticlePublished): Either[String, ArticleEvent] =
     for _ <- requireSchemaVersion(wire.schemaVersion, ArticlePublished.CurrentSchemaVersion)

--- a/apps/api/infrastructure/src/test/scala/morecat/infrastructure/json/ArticleEventJsonCodecSpec.scala
+++ b/apps/api/infrastructure/src/test/scala/morecat/infrastructure/json/ArticleEventJsonCodecSpec.scala
@@ -8,13 +8,13 @@ object ArticleEventJsonCodecSpec extends ZIOSpecDefault:
   def spec = suite("ArticleEventJsonCodec")(
     test("round-trips ArticleDrafted without leaking JSON concerns into domain") {
       val event =
-        ArticleDrafted(Slug.applyUnsafe("hello-world"), Title.applyUnsafe("Hello"), "body")
+        ArticleDrafted.applyUnsafe("hello-world", "Hello", "body")
 
       assertTrue(ArticleEventJsonCodec.decode(ArticleEventJsonCodec.encode(event)) == Right(event))
     },
     test("omits non-applicable fields when encoding ArticleDrafted") {
       val event =
-        ArticleDrafted(Slug.applyUnsafe("hello-world"), Title.applyUnsafe("Hello"), "body")
+        ArticleDrafted.applyUnsafe("hello-world", "Hello", "body")
 
       assertTrue(!ArticleEventJsonCodec.encode(event).contains("publishedAt"))
     },
@@ -57,6 +57,20 @@ object ArticleEventJsonCodecSpec extends ZIOSpecDefault:
         """{"eventType":"ArticleDrafted","schemaVersion":1,"slug":"../bad","title":"Hello","body":"body"}"""
 
       assertTrue(ArticleEventJsonCodec.decode(json).isLeft)
+    },
+    test("preserves oversized historical ArticleDrafted bodies at the decode boundary") {
+      val oversizedBody = "x" * (ArticleBody.MaxBytes + 1)
+      val json =
+        s"""{"eventType":"ArticleDrafted","schemaVersion":1,"slug":"hello-world","title":"Hello","body":"$oversizedBody"}"""
+
+      assertTrue(
+        ArticleEventJsonCodec.decode(json) ==
+          ArticleDrafted
+            .fromStoredEvent("hello-world", "Hello", oversizedBody)
+            .map(identity)
+            .left
+            .map(_.mkString(","))
+      )
     },
     test("rejects ArticleDrafted when a required field is missing") {
       val json =


### PR DESCRIPTION
## Summary

- Add `ArticleBody` as a domain value object with a UTF-8 byte size limit.
- Move `ArticleDrafted` validation into a domain smart constructor that collects slug, title, and body errors together.
- Update the application service and JSON decode boundary to construct `ArticleDrafted` through the domain model.

## Why

Draft creation validation belongs to the article draft event model rather than the command service. This keeps `ArticleCommandService` focused on orchestration and makes invalid draft state unrepresentable outside the domain smart constructor.

## Validation

- `nix develop -c sbt test`
- `nix develop -c sbt scalafmtCheckAll clean coverage domain/test application/test infrastructure/test coverageAggregate`