### PR TITLE
[codex] Add Firestore event store boundary

### DIFF
--- a/apps/api/infrastructure/src/main/scala/morecat/infrastructure/firestore/FirestoreArticleEventStore.scala
+++ b/apps/api/infrastructure/src/main/scala/morecat/infrastructure/firestore/FirestoreArticleEventStore.scala
@@ -1,0 +1,40 @@
+package morecat.infrastructure.firestore
+
+import morecat.application.*
+import morecat.domain.*
+import morecat.infrastructure.json.ArticleEventJsonCodec
+import zio.*
+
+final class FirestoreArticleEventStore(backend: FirestoreEventStoreBackend)
+    extends ArticleEventStore:
+
+  def createDraft(articleId: ArticleId, event: ArticleDrafted): IO[EventStoreError, Unit] =
+    backend.runTransaction { tx =>
+      tx.createSlugReservation(event.slug, articleId) *>
+        tx.createArticleEvent(articleId, seq = 1L, ArticleEventJsonCodec.encode(event))
+    }
+
+  def load(articleId: ArticleId): IO[EventStoreError, Chunk[SequencedArticleEvent]] =
+    backend
+      .loadEvents(articleId)
+      .flatMap { storedEvents =>
+        ZIO.foreach(storedEvents.sortBy(_.seq)) { stored =>
+          ZIO
+            .fromEither(ArticleEventJsonCodec.decode(stored.json))
+            .map(event => SequencedArticleEvent(stored.seq, event))
+            .mapError(error => EventStoreError.Unavailable(error))
+        }
+      }
+
+  def append(
+    articleId: ArticleId,
+    expectedVersion: Long,
+    event: ArticleEvent
+  ): IO[EventStoreError, Unit] =
+    backend.runTransaction { tx =>
+      tx.createArticleEvent(
+        articleId,
+        seq = expectedVersion + 1L,
+        ArticleEventJsonCodec.encode(event),
+      )
+    }

--- a/apps/api/infrastructure/src/main/scala/morecat/infrastructure/firestore/FirestoreEventStoreBackend.scala
+++ b/apps/api/infrastructure/src/main/scala/morecat/infrastructure/firestore/FirestoreEventStoreBackend.scala
@@ -1,0 +1,18 @@
+package morecat.infrastructure.firestore
+
+import morecat.application.EventStoreError
+import morecat.domain.*
+import zio.*
+
+final case class StoredFirestoreArticleEvent(seq: Long, json: String)
+
+trait FirestoreEventStoreTransaction:
+  def createSlugReservation(slug: Slug, articleId: ArticleId): IO[EventStoreError, Unit]
+  def createArticleEvent(articleId: ArticleId, seq: Long, json: String): IO[EventStoreError, Unit]
+
+trait FirestoreEventStoreBackend:
+  def runTransaction[A](
+    effect: FirestoreEventStoreTransaction => IO[EventStoreError, A]
+  ): IO[EventStoreError, A]
+
+  def loadEvents(articleId: ArticleId): IO[EventStoreError, Chunk[StoredFirestoreArticleEvent]]

--- a/apps/api/infrastructure/src/test/scala/morecat/infrastructure/firestore/FirestoreArticleEventStoreSpec.scala
+++ b/apps/api/infrastructure/src/test/scala/morecat/infrastructure/firestore/FirestoreArticleEventStoreSpec.scala
@@ -79,6 +79,17 @@ object FirestoreArticleEventStoreSpec extends ZIOSpecDefault:
         Assertion.fails(Assertion.equalTo(EventStoreError.VersionConflict))
       )
     },
+    test("load maps undecodable stored events to Unavailable") {
+      val backend = InMemoryFirestoreEventStoreBackend.empty
+        .withRawEvent(articleId, 1L, """{"eventType":"Unknown"}""")
+      val store = FirestoreArticleEventStore(backend)
+
+      assertZIO(store.load(articleId).exit)(
+        Assertion.fails(
+          Assertion.equalTo(EventStoreError.Unavailable("unsupported eventType: Unknown"))
+        )
+      )
+    },
   )
 
 private final class InMemoryFirestoreEventStoreBackend private (
@@ -95,10 +106,17 @@ private final class InMemoryFirestoreEventStoreBackend private (
     seq: Long,
     event: ArticleEvent,
   ): InMemoryFirestoreEventStoreBackend =
+    withRawEvent(articleId, seq, ArticleEventJsonCodec.encode(event))
+
+  def withRawEvent(
+    articleId: ArticleId,
+    seq: Long,
+    json: String,
+  ): InMemoryFirestoreEventStoreBackend =
     val articleEvents = events.getOrElse(articleId.asString, Map.empty)
     events = events.updated(
       articleId.asString,
-      articleEvents.updated(seq, ArticleEventJsonCodec.encode(event)),
+      articleEvents.updated(seq, json),
     )
     this
 

--- a/apps/api/infrastructure/src/test/scala/morecat/infrastructure/firestore/FirestoreArticleEventStoreSpec.scala
+++ b/apps/api/infrastructure/src/test/scala/morecat/infrastructure/firestore/FirestoreArticleEventStoreSpec.scala
@@ -1,0 +1,165 @@
+package morecat.infrastructure.firestore
+
+import morecat.application.*
+import morecat.domain.*
+import morecat.infrastructure.json.ArticleEventJsonCodec
+import zio.*
+import zio.test.*
+
+object FirestoreArticleEventStoreSpec extends ZIOSpecDefault:
+
+  private val articleId =
+    ArticleId.fromString("018f4edc-1f5a-7c4b-aef9-000000000001")
+  private val otherArticleId =
+    ArticleId.fromString("018f4edc-1f5a-7c4b-aef9-000000000002")
+  private val draft =
+    ArticleDrafted.applyUnsafe("hello-world", "Hello", "body")
+
+  def spec = suite("FirestoreArticleEventStore")(
+    test("createDraft reserves the slug and creates seq 1 in one transaction") {
+      val backend = InMemoryFirestoreEventStoreBackend.empty
+      val store = FirestoreArticleEventStore(backend)
+
+      for
+        _ <- store.createDraft(articleId, draft)
+        events <- store.load(articleId)
+      yield assertTrue(
+        backend.slugOwner("hello-world") == Some(articleId.asString),
+        events == Chunk(SequencedArticleEvent(1L, draft)),
+      )
+    },
+    test("createDraft rolls back the slug reservation when seq 1 already exists") {
+      val backend = InMemoryFirestoreEventStoreBackend.empty
+        .withEvent(articleId, 1L, ArticlePublished(publishedAt = 999L))
+      val store = FirestoreArticleEventStore(backend)
+
+      for exit <- store.createDraft(articleId, draft).exit
+      yield assertTrue(
+        exit == Exit.fail(EventStoreError.VersionConflict),
+        backend.slugOwner("hello-world").isEmpty,
+      )
+    },
+    test("createDraft rolls back the event when the slug is already reserved") {
+      val backend = InMemoryFirestoreEventStoreBackend.empty
+        .withSlug("hello-world", otherArticleId)
+      val store = FirestoreArticleEventStore(backend)
+
+      for
+        exit <- store.createDraft(articleId, draft).exit
+        events <- store.load(articleId)
+      yield assertTrue(
+        exit == Exit.fail(EventStoreError.SlugAlreadyReserved),
+        events.isEmpty,
+      )
+    },
+    test("append creates expectedVersion plus one") {
+      val backend = InMemoryFirestoreEventStoreBackend.empty
+        .withEvent(articleId, 1L, draft)
+      val store = FirestoreArticleEventStore(backend)
+
+      for
+        _ <- store.append(articleId, expectedVersion = 1L, ArticlePublished(publishedAt = 999L))
+        events <- store.load(articleId)
+      yield assertTrue(
+        events == Chunk(
+          SequencedArticleEvent(1L, draft),
+          SequencedArticleEvent(2L, ArticlePublished(publishedAt = 999L)),
+        )
+      )
+    },
+    test("append maps an existing target seq to VersionConflict") {
+      val backend = InMemoryFirestoreEventStoreBackend.empty
+        .withEvent(articleId, 1L, draft)
+        .withEvent(articleId, 2L, ArticlePublished(publishedAt = 999L))
+      val store = FirestoreArticleEventStore(backend)
+
+      assertZIO(
+        store.append(articleId, expectedVersion = 1L, ArticlePublished(publishedAt = 1000L)).exit
+      )(
+        Assertion.fails(Assertion.equalTo(EventStoreError.VersionConflict))
+      )
+    },
+  )
+
+private final class InMemoryFirestoreEventStoreBackend private (
+  private var slugs: Map[String, String],
+  private var events: Map[String, Map[Long, String]],
+) extends FirestoreEventStoreBackend:
+
+  def withSlug(slug: String, articleId: ArticleId): InMemoryFirestoreEventStoreBackend =
+    slugs = slugs.updated(slug, articleId.asString)
+    this
+
+  def withEvent(
+    articleId: ArticleId,
+    seq: Long,
+    event: ArticleEvent,
+  ): InMemoryFirestoreEventStoreBackend =
+    val articleEvents = events.getOrElse(articleId.asString, Map.empty)
+    events = events.updated(
+      articleId.asString,
+      articleEvents.updated(seq, ArticleEventJsonCodec.encode(event)),
+    )
+    this
+
+  def slugOwner(slug: String): Option[String] =
+    slugs.get(slug)
+
+  def runTransaction[A](
+    effect: FirestoreEventStoreTransaction => IO[EventStoreError, A]
+  ): IO[EventStoreError, A] =
+    for
+      stagedSlugs <- Ref.make(slugs)
+      stagedEvents <- Ref.make(events)
+      result <- effect(InMemoryTransaction(stagedSlugs, stagedEvents)).tap { _ =>
+        for
+          committedSlugs <- stagedSlugs.get
+          committedEvents <- stagedEvents.get
+          _ <- ZIO.succeed {
+            slugs = committedSlugs
+            events = committedEvents
+          }
+        yield ()
+      }
+    yield result
+
+  def loadEvents(articleId: ArticleId): IO[EventStoreError, Chunk[StoredFirestoreArticleEvent]] =
+    ZIO.succeed {
+      Chunk.fromIterable(
+        events
+          .getOrElse(articleId.asString, Map.empty)
+          .toSeq
+          .map((seq, json) => StoredFirestoreArticleEvent(seq, json))
+      )
+    }
+
+private object InMemoryFirestoreEventStoreBackend:
+  def empty: InMemoryFirestoreEventStoreBackend =
+    InMemoryFirestoreEventStoreBackend(Map.empty, Map.empty)
+
+private final class InMemoryTransaction(
+  slugs: Ref[Map[String, String]],
+  events: Ref[Map[String, Map[Long, String]]],
+) extends FirestoreEventStoreTransaction:
+
+  def createSlugReservation(slug: Slug, articleId: ArticleId): IO[EventStoreError, Unit] =
+    slugs.modify { current =>
+      val slugValue = slug.toString
+      if current.contains(slugValue) then (ZIO.fail(EventStoreError.SlugAlreadyReserved), current)
+      else (ZIO.unit, current.updated(slugValue, articleId.asString))
+    }.flatten
+
+  def createArticleEvent(
+    articleId: ArticleId,
+    seq: Long,
+    json: String,
+  ): IO[EventStoreError, Unit] =
+    events.modify { current =>
+      val articleEvents = current.getOrElse(articleId.asString, Map.empty)
+      if articleEvents.contains(seq) then (ZIO.fail(EventStoreError.VersionConflict), current)
+      else
+        (
+          ZIO.unit,
+          current.updated(articleId.asString, articleEvents.updated(seq, json)),
+        )
+    }.flatten


### PR DESCRIPTION
## Summary

- Add a Firestore-backed `ArticleEventStore` boundary in infrastructure.
- Encode/decode article events at the infrastructure JSON boundary while preserving application/domain ports.
- Add contract tests for draft creation atomicity, rollback behavior, append sequencing, version conflicts, and undecodable stored events using an in-memory backend.

## Why

This continues `docs/slice-1-plan.md` task 2 by fixing the event-store contract before wiring the real Google Firestore SDK adapter. The important behavior is that slug reservation and `events/1` creation are treated as one transaction.

## Validation

- `nix develop -c sbt infrastructure/test`
- `nix develop -c sbt scalafmtCheckAll`
- `nix develop -c sbt clean coverage domain/test application/test infrastructure/test coverageAggregate`

Note: the first combined validation attempt hit a transient Nix store path error before sbt started; rerunning the checks separately passed.