### PR TITLE
[codex] Add Firestore document client backend

### DIFF
--- a/apps/api/infrastructure/src/main/scala/morecat/infrastructure/firestore/FirestoreArticleEventStore.scala
+++ b/apps/api/infrastructure/src/main/scala/morecat/infrastructure/firestore/FirestoreArticleEventStore.scala
@@ -10,8 +10,16 @@ final class FirestoreArticleEventStore(backend: FirestoreEventStoreBackend)
 
   def createDraft(articleId: ArticleId, event: ArticleDrafted): IO[EventStoreError, Unit] =
     backend.runTransaction { tx =>
-      tx.createSlugReservation(event.slug, articleId) *>
-        tx.createArticleEvent(articleId, seq = 1L, ArticleEventJsonCodec.encode(event))
+      tx.createDocument(
+        FirestoreDocumentModel.slugReservationPath(event.slug),
+        FirestoreDocumentModel.slugReservationData(articleId),
+        EventStoreError.SlugAlreadyReserved,
+      ) *>
+        tx.createDocument(
+          FirestoreDocumentModel.articleEventPath(articleId, seq = 1L),
+          FirestoreDocumentModel.articleEventData(ArticleEventJsonCodec.encode(event)),
+          EventStoreError.VersionConflict,
+        )
     }
 
   def load(articleId: ArticleId): IO[EventStoreError, Chunk[SequencedArticleEvent]] =
@@ -32,9 +40,9 @@ final class FirestoreArticleEventStore(backend: FirestoreEventStoreBackend)
     event: ArticleEvent
   ): IO[EventStoreError, Unit] =
     backend.runTransaction { tx =>
-      tx.createArticleEvent(
-        articleId,
-        seq = expectedVersion + 1L,
-        ArticleEventJsonCodec.encode(event),
+      tx.createDocument(
+        FirestoreDocumentModel.articleEventPath(articleId, seq = expectedVersion + 1L),
+        FirestoreDocumentModel.articleEventData(ArticleEventJsonCodec.encode(event)),
+        EventStoreError.VersionConflict,
       )
     }

--- a/apps/api/infrastructure/src/main/scala/morecat/infrastructure/firestore/FirestoreClientEventStoreBackend.scala
+++ b/apps/api/infrastructure/src/main/scala/morecat/infrastructure/firestore/FirestoreClientEventStoreBackend.scala
@@ -1,0 +1,57 @@
+package morecat.infrastructure.firestore
+
+import morecat.application.EventStoreError
+import morecat.domain.ArticleId
+import zio.*
+
+final class FirestoreClientEventStoreBackend(client: FirestoreDocumentClient)
+    extends FirestoreEventStoreBackend:
+
+  def runTransaction[A](
+    effect: FirestoreEventStoreTransaction => IO[EventStoreError, A]
+  ): IO[EventStoreError, A] =
+    client.transaction(txClient => effect(FirestoreClientEventStoreTransaction(txClient)))
+
+  def loadEvents(articleId: ArticleId): IO[EventStoreError, Chunk[StoredFirestoreArticleEvent]] =
+    client
+      .listDocuments(FirestoreDocumentModel.articleEventsCollectionPath(articleId))
+      .mapError(toEventStoreError)
+      .flatMap { documents =>
+        ZIO.foreach(documents) { document =>
+          for
+            seq <- parseSeq(document.id)
+            json <- ZIO
+              .fromOption(document.data.get(FirestoreDocumentModel.EventJsonField))
+              .orElseFail(
+                EventStoreError.Unavailable(
+                  s"missing Firestore field: ${FirestoreDocumentModel.EventJsonField}"
+                )
+              )
+          yield StoredFirestoreArticleEvent(seq, json)
+        }
+      }
+
+  private def parseSeq(value: String): IO[EventStoreError, Long] =
+    ZIO
+      .attempt(value.toLong)
+      .mapError(_ => EventStoreError.Unavailable(s"invalid event seq document id: $value"))
+
+  private def toEventStoreError(error: FirestoreClientError): EventStoreError =
+    error match
+      case FirestoreClientError.AlreadyExists =>
+        EventStoreError.Unavailable("unexpected Firestore create conflict")
+      case FirestoreClientError.Unavailable(message) =>
+        EventStoreError.Unavailable(message)
+
+private final class FirestoreClientEventStoreTransaction(client: FirestoreDocumentClient)
+    extends FirestoreEventStoreTransaction:
+
+  def createDocument(
+    path: FirestoreDocumentPath,
+    data: Map[String, String],
+    alreadyExistsError: EventStoreError,
+  ): IO[EventStoreError, Unit] =
+    client.create(path, data).mapError {
+      case FirestoreClientError.AlreadyExists        => alreadyExistsError
+      case FirestoreClientError.Unavailable(message) => EventStoreError.Unavailable(message)
+    }

--- a/apps/api/infrastructure/src/main/scala/morecat/infrastructure/firestore/FirestoreClientEventStoreBackend.scala
+++ b/apps/api/infrastructure/src/main/scala/morecat/infrastructure/firestore/FirestoreClientEventStoreBackend.scala
@@ -17,18 +17,20 @@ final class FirestoreClientEventStoreBackend(client: FirestoreDocumentClient)
       .listDocuments(FirestoreDocumentModel.articleEventsCollectionPath(articleId))
       .mapError(toEventStoreError)
       .flatMap { documents =>
-        ZIO.foreach(documents) { document =>
-          for
-            seq <- parseSeq(document.id)
-            json <- ZIO
-              .fromOption(document.data.get(FirestoreDocumentModel.EventJsonField))
-              .orElseFail(
-                EventStoreError.Unavailable(
-                  s"missing Firestore field: ${FirestoreDocumentModel.EventJsonField}"
+        ZIO
+          .foreach(documents) { document =>
+            for
+              seq <- parseSeq(document.id)
+              json <- ZIO
+                .fromOption(document.data.get(FirestoreDocumentModel.EventJsonField))
+                .orElseFail(
+                  EventStoreError.Unavailable(
+                    s"missing Firestore field: ${FirestoreDocumentModel.EventJsonField}"
+                  )
                 )
-              )
-          yield StoredFirestoreArticleEvent(seq, json)
-        }
+            yield StoredFirestoreArticleEvent(seq, json)
+          }
+          .map(_.sortBy(_.seq))
       }
 
   private def parseSeq(value: String): IO[EventStoreError, Long] =
@@ -43,7 +45,7 @@ final class FirestoreClientEventStoreBackend(client: FirestoreDocumentClient)
       case FirestoreClientError.Unavailable(message) =>
         EventStoreError.Unavailable(message)
 
-private final class FirestoreClientEventStoreTransaction(client: FirestoreDocumentClient)
+private final class FirestoreClientEventStoreTransaction(tx: FirestoreDocumentTransaction)
     extends FirestoreEventStoreTransaction:
 
   def createDocument(
@@ -51,7 +53,7 @@ private final class FirestoreClientEventStoreTransaction(client: FirestoreDocume
     data: Map[String, String],
     alreadyExistsError: EventStoreError,
   ): IO[EventStoreError, Unit] =
-    client.create(path, data).mapError {
+    tx.create(path, data).mapError {
       case FirestoreClientError.AlreadyExists        => alreadyExistsError
       case FirestoreClientError.Unavailable(message) => EventStoreError.Unavailable(message)
     }

--- a/apps/api/infrastructure/src/main/scala/morecat/infrastructure/firestore/FirestoreDocumentClient.scala
+++ b/apps/api/infrastructure/src/main/scala/morecat/infrastructure/firestore/FirestoreDocumentClient.scala
@@ -1,0 +1,21 @@
+package morecat.infrastructure.firestore
+
+import morecat.application.EventStoreError
+import zio.*
+
+final case class FirestoreDocument(id: String, data: Map[String, String])
+
+enum FirestoreClientError:
+  case AlreadyExists
+  case Unavailable(message: String)
+
+trait FirestoreDocumentClient:
+  def transaction[A](
+    effect: FirestoreDocumentClient => IO[EventStoreError, A]
+  ): IO[EventStoreError, A]
+
+  def create(path: FirestoreDocumentPath, data: Map[String, String]): IO[FirestoreClientError, Unit]
+
+  def listDocuments(
+    path: FirestoreDocumentPath
+  ): IO[FirestoreClientError, Chunk[FirestoreDocument]]

--- a/apps/api/infrastructure/src/main/scala/morecat/infrastructure/firestore/FirestoreDocumentClient.scala
+++ b/apps/api/infrastructure/src/main/scala/morecat/infrastructure/firestore/FirestoreDocumentClient.scala
@@ -11,11 +11,12 @@ enum FirestoreClientError:
 
 trait FirestoreDocumentClient:
   def transaction[A](
-    effect: FirestoreDocumentClient => IO[EventStoreError, A]
+    effect: FirestoreDocumentTransaction => IO[EventStoreError, A]
   ): IO[EventStoreError, A]
-
-  def create(path: FirestoreDocumentPath, data: Map[String, String]): IO[FirestoreClientError, Unit]
 
   def listDocuments(
     path: FirestoreDocumentPath
   ): IO[FirestoreClientError, Chunk[FirestoreDocument]]
+
+trait FirestoreDocumentTransaction:
+  def create(path: FirestoreDocumentPath, data: Map[String, String]): IO[FirestoreClientError, Unit]

--- a/apps/api/infrastructure/src/main/scala/morecat/infrastructure/firestore/FirestoreDocumentModel.scala
+++ b/apps/api/infrastructure/src/main/scala/morecat/infrastructure/firestore/FirestoreDocumentModel.scala
@@ -1,0 +1,30 @@
+package morecat.infrastructure.firestore
+
+import morecat.domain.*
+
+final case class FirestoreDocumentPath private (segments: Vector[String]):
+  def asString: String =
+    segments.mkString("/")
+
+object FirestoreDocumentPath:
+  def apply(first: String, rest: String*): FirestoreDocumentPath =
+    FirestoreDocumentPath((first +: rest).toVector)
+
+object FirestoreDocumentModel:
+  val EventJsonField: String = "json"
+  val SlugArticleIdField: String = "articleId"
+
+  def articleEventPath(articleId: ArticleId, seq: Long): FirestoreDocumentPath =
+    FirestoreDocumentPath("articles", articleId.asString, "events", seq.toString)
+
+  def articleEventsCollectionPath(articleId: ArticleId): FirestoreDocumentPath =
+    FirestoreDocumentPath("articles", articleId.asString, "events")
+
+  def slugReservationPath(slug: Slug): FirestoreDocumentPath =
+    FirestoreDocumentPath("slugs", slug.toString)
+
+  def articleEventData(json: String): Map[String, String] =
+    Map(EventJsonField -> json)
+
+  def slugReservationData(articleId: ArticleId): Map[String, String] =
+    Map(SlugArticleIdField -> articleId.asString)

--- a/apps/api/infrastructure/src/main/scala/morecat/infrastructure/firestore/FirestoreEventStoreBackend.scala
+++ b/apps/api/infrastructure/src/main/scala/morecat/infrastructure/firestore/FirestoreEventStoreBackend.scala
@@ -1,14 +1,17 @@
 package morecat.infrastructure.firestore
 
 import morecat.application.EventStoreError
-import morecat.domain.*
+import morecat.domain.ArticleId
 import zio.*
 
 final case class StoredFirestoreArticleEvent(seq: Long, json: String)
 
 trait FirestoreEventStoreTransaction:
-  def createSlugReservation(slug: Slug, articleId: ArticleId): IO[EventStoreError, Unit]
-  def createArticleEvent(articleId: ArticleId, seq: Long, json: String): IO[EventStoreError, Unit]
+  def createDocument(
+    path: FirestoreDocumentPath,
+    data: Map[String, String],
+    alreadyExistsError: EventStoreError,
+  ): IO[EventStoreError, Unit]
 
 trait FirestoreEventStoreBackend:
   def runTransaction[A](

--- a/apps/api/infrastructure/src/test/scala/morecat/infrastructure/firestore/FirestoreArticleEventStoreSpec.scala
+++ b/apps/api/infrastructure/src/test/scala/morecat/infrastructure/firestore/FirestoreArticleEventStoreSpec.scala
@@ -160,24 +160,50 @@ private final class InMemoryTransaction(
   events: Ref[Map[String, Map[Long, String]]],
 ) extends FirestoreEventStoreTransaction:
 
-  def createSlugReservation(slug: Slug, articleId: ArticleId): IO[EventStoreError, Unit] =
+  def createDocument(
+    path: FirestoreDocumentPath,
+    data: Map[String, String],
+    alreadyExistsError: EventStoreError,
+  ): IO[EventStoreError, Unit] =
+    path.segments.toList match
+      case "slugs" :: slug :: Nil =>
+        createSlugReservation(
+          slug,
+          data(FirestoreDocumentModel.SlugArticleIdField),
+          alreadyExistsError,
+        )
+      case "articles" :: articleId :: "events" :: rawSeq :: Nil =>
+        createArticleEvent(
+          articleId,
+          rawSeq.toLong,
+          data(FirestoreDocumentModel.EventJsonField),
+          alreadyExistsError,
+        )
+      case other =>
+        ZIO.fail(EventStoreError.Unavailable(s"unsupported Firestore path: ${other.mkString("/")}"))
+
+  private def createSlugReservation(
+    slug: String,
+    articleId: String,
+    alreadyExistsError: EventStoreError,
+  ): IO[EventStoreError, Unit] =
     slugs.modify { current =>
-      val slugValue = slug.toString
-      if current.contains(slugValue) then (ZIO.fail(EventStoreError.SlugAlreadyReserved), current)
-      else (ZIO.unit, current.updated(slugValue, articleId.asString))
+      if current.contains(slug) then (ZIO.fail(alreadyExistsError), current)
+      else (ZIO.unit, current.updated(slug, articleId))
     }.flatten
 
-  def createArticleEvent(
-    articleId: ArticleId,
+  private def createArticleEvent(
+    articleId: String,
     seq: Long,
     json: String,
+    alreadyExistsError: EventStoreError,
   ): IO[EventStoreError, Unit] =
     events.modify { current =>
-      val articleEvents = current.getOrElse(articleId.asString, Map.empty)
-      if articleEvents.contains(seq) then (ZIO.fail(EventStoreError.VersionConflict), current)
+      val articleEvents = current.getOrElse(articleId, Map.empty)
+      if articleEvents.contains(seq) then (ZIO.fail(alreadyExistsError), current)
       else
         (
           ZIO.unit,
-          current.updated(articleId.asString, articleEvents.updated(seq, json)),
+          current.updated(articleId, articleEvents.updated(seq, json)),
         )
     }.flatten

--- a/apps/api/infrastructure/src/test/scala/morecat/infrastructure/firestore/FirestoreClientEventStoreBackendSpec.scala
+++ b/apps/api/infrastructure/src/test/scala/morecat/infrastructure/firestore/FirestoreClientEventStoreBackendSpec.scala
@@ -62,7 +62,7 @@ object FirestoreClientEventStoreBackendSpec extends ZIOSpecDefault:
           .exit
       )(Assertion.fails(Assertion.equalTo(EventStoreError.Unavailable("down"))))
     },
-    test("loadEvents reads the article events collection and parses seq document ids") {
+    test("loadEvents reads the article events collection and returns events sorted by seq") {
       val client = RecordingFirestoreDocumentClient(
         listedDocuments = Chunk(
           FirestoreDocument(
@@ -81,8 +81,8 @@ object FirestoreClientEventStoreBackendSpec extends ZIOSpecDefault:
       yield assertTrue(
         client.listed == List(FirestoreDocumentModel.articleEventsCollectionPath(articleId)),
         events == Chunk(
-          StoredFirestoreArticleEvent(2L, """{"eventType":"ArticlePublished"}"""),
           StoredFirestoreArticleEvent(1L, """{"eventType":"ArticleDrafted"}"""),
+          StoredFirestoreArticleEvent(2L, """{"eventType":"ArticlePublished"}"""),
         ),
       )
     },
@@ -137,7 +137,7 @@ object FirestoreClientEventStoreBackendSpec extends ZIOSpecDefault:
   )
 
 private final class RecordingFirestoreDocumentClient(
-  createResult: IO[FirestoreClientError, Unit] = ZIO.unit,
+  val createResult: IO[FirestoreClientError, Unit] = ZIO.unit,
   listedDocuments: Chunk[FirestoreDocument] = Chunk.empty,
   listResult: IO[FirestoreClientError, Unit] = ZIO.unit,
 ) extends FirestoreDocumentClient:
@@ -146,19 +146,11 @@ private final class RecordingFirestoreDocumentClient(
   var listed: List[FirestoreDocumentPath] = Nil
 
   def transaction[A](
-    effect: FirestoreDocumentClient => IO[EventStoreError, A]
+    effect: FirestoreDocumentTransaction => IO[EventStoreError, A]
   ): IO[EventStoreError, A] =
     ZIO.succeed {
       transactionCount = transactionCount + 1
-    } *> effect(this)
-
-  def create(
-    path: FirestoreDocumentPath,
-    data: Map[String, String]
-  ): IO[FirestoreClientError, Unit] =
-    createResult *> ZIO.succeed {
-      created = created :+ (path, data)
-    }
+    } *> effect(RecordingFirestoreDocumentTransaction(this))
 
   def listDocuments(
     path: FirestoreDocumentPath
@@ -166,3 +158,14 @@ private final class RecordingFirestoreDocumentClient(
     ZIO.succeed {
       listed = listed :+ path
     } *> listResult *> ZIO.succeed(listedDocuments)
+
+private final class RecordingFirestoreDocumentTransaction(client: RecordingFirestoreDocumentClient)
+    extends FirestoreDocumentTransaction:
+
+  def create(
+    path: FirestoreDocumentPath,
+    data: Map[String, String]
+  ): IO[FirestoreClientError, Unit] =
+    client.createResult *> ZIO.succeed {
+      client.created = client.created :+ (path, data)
+    }

--- a/apps/api/infrastructure/src/test/scala/morecat/infrastructure/firestore/FirestoreClientEventStoreBackendSpec.scala
+++ b/apps/api/infrastructure/src/test/scala/morecat/infrastructure/firestore/FirestoreClientEventStoreBackendSpec.scala
@@ -1,0 +1,168 @@
+package morecat.infrastructure.firestore
+
+import morecat.application.EventStoreError
+import morecat.domain.ArticleId
+import zio.*
+import zio.test.*
+
+object FirestoreClientEventStoreBackendSpec extends ZIOSpecDefault:
+
+  private val articleId =
+    ArticleId.fromString("018f4edc-1f5a-7c4b-aef9-000000000001")
+
+  def spec = suite("FirestoreClientEventStoreBackend")(
+    test("createDocument delegates path and data inside a transaction") {
+      val client = RecordingFirestoreDocumentClient()
+      val backend = FirestoreClientEventStoreBackend(client)
+      val path = FirestoreDocumentPath("slugs", "hello-world")
+      val data = Map("articleId" -> articleId.asString)
+
+      for _ <- backend.runTransaction(
+          _.createDocument(path, data, EventStoreError.SlugAlreadyReserved)
+        )
+      yield assertTrue(
+        client.transactionCount == 1,
+        client.created == List((path, data)),
+      )
+    },
+    test("createDocument maps AlreadyExists to the caller supplied conflict") {
+      val client = RecordingFirestoreDocumentClient(createResult =
+        ZIO.fail(FirestoreClientError.AlreadyExists)
+      )
+      val backend = FirestoreClientEventStoreBackend(client)
+
+      assertZIO(
+        backend
+          .runTransaction(
+            _.createDocument(
+              FirestoreDocumentPath("slugs", "hello-world"),
+              Map("articleId" -> articleId.asString),
+              EventStoreError.SlugAlreadyReserved,
+            )
+          )
+          .exit
+      )(Assertion.fails(Assertion.equalTo(EventStoreError.SlugAlreadyReserved)))
+    },
+    test("createDocument maps client unavailability to EventStoreError.Unavailable") {
+      val client =
+        RecordingFirestoreDocumentClient(createResult =
+          ZIO.fail(FirestoreClientError.Unavailable("down"))
+        )
+      val backend = FirestoreClientEventStoreBackend(client)
+
+      assertZIO(
+        backend
+          .runTransaction(
+            _.createDocument(
+              FirestoreDocumentPath("slugs", "hello-world"),
+              Map("articleId" -> articleId.asString),
+              EventStoreError.SlugAlreadyReserved,
+            )
+          )
+          .exit
+      )(Assertion.fails(Assertion.equalTo(EventStoreError.Unavailable("down"))))
+    },
+    test("loadEvents reads the article events collection and parses seq document ids") {
+      val client = RecordingFirestoreDocumentClient(
+        listedDocuments = Chunk(
+          FirestoreDocument(
+            "2",
+            Map(FirestoreDocumentModel.EventJsonField -> """{"eventType":"ArticlePublished"}""")
+          ),
+          FirestoreDocument(
+            "1",
+            Map(FirestoreDocumentModel.EventJsonField -> """{"eventType":"ArticleDrafted"}""")
+          ),
+        )
+      )
+      val backend = FirestoreClientEventStoreBackend(client)
+
+      for events <- backend.loadEvents(articleId)
+      yield assertTrue(
+        client.listed == List(FirestoreDocumentModel.articleEventsCollectionPath(articleId)),
+        events == Chunk(
+          StoredFirestoreArticleEvent(2L, """{"eventType":"ArticlePublished"}"""),
+          StoredFirestoreArticleEvent(1L, """{"eventType":"ArticleDrafted"}"""),
+        ),
+      )
+    },
+    test("loadEvents rejects non numeric event document ids") {
+      val client = RecordingFirestoreDocumentClient(
+        listedDocuments = Chunk(
+          FirestoreDocument("not-a-seq", Map(FirestoreDocumentModel.EventJsonField -> "{}"))
+        )
+      )
+      val backend = FirestoreClientEventStoreBackend(client)
+
+      assertZIO(backend.loadEvents(articleId).exit)(
+        Assertion.fails(
+          Assertion.equalTo(EventStoreError.Unavailable("invalid event seq document id: not-a-seq"))
+        )
+      )
+    },
+    test("loadEvents rejects documents missing the JSON payload field") {
+      val client = RecordingFirestoreDocumentClient(
+        listedDocuments = Chunk(FirestoreDocument("1", Map.empty))
+      )
+      val backend = FirestoreClientEventStoreBackend(client)
+
+      assertZIO(backend.loadEvents(articleId).exit)(
+        Assertion.fails(
+          Assertion.equalTo(EventStoreError.Unavailable("missing Firestore field: json"))
+        )
+      )
+    },
+    test("loadEvents maps client unavailability to EventStoreError.Unavailable") {
+      val client =
+        RecordingFirestoreDocumentClient(listResult =
+          ZIO.fail(FirestoreClientError.Unavailable("down"))
+        )
+      val backend = FirestoreClientEventStoreBackend(client)
+
+      assertZIO(backend.loadEvents(articleId).exit)(
+        Assertion.fails(Assertion.equalTo(EventStoreError.Unavailable("down")))
+      )
+    },
+    test("loadEvents maps unexpected AlreadyExists to Unavailable") {
+      val client =
+        RecordingFirestoreDocumentClient(listResult = ZIO.fail(FirestoreClientError.AlreadyExists))
+      val backend = FirestoreClientEventStoreBackend(client)
+
+      assertZIO(backend.loadEvents(articleId).exit)(
+        Assertion.fails(
+          Assertion.equalTo(EventStoreError.Unavailable("unexpected Firestore create conflict"))
+        )
+      )
+    },
+  )
+
+private final class RecordingFirestoreDocumentClient(
+  createResult: IO[FirestoreClientError, Unit] = ZIO.unit,
+  listedDocuments: Chunk[FirestoreDocument] = Chunk.empty,
+  listResult: IO[FirestoreClientError, Unit] = ZIO.unit,
+) extends FirestoreDocumentClient:
+  var transactionCount: Int = 0
+  var created: List[(FirestoreDocumentPath, Map[String, String])] = Nil
+  var listed: List[FirestoreDocumentPath] = Nil
+
+  def transaction[A](
+    effect: FirestoreDocumentClient => IO[EventStoreError, A]
+  ): IO[EventStoreError, A] =
+    ZIO.succeed {
+      transactionCount = transactionCount + 1
+    } *> effect(this)
+
+  def create(
+    path: FirestoreDocumentPath,
+    data: Map[String, String]
+  ): IO[FirestoreClientError, Unit] =
+    createResult *> ZIO.succeed {
+      created = created :+ (path, data)
+    }
+
+  def listDocuments(
+    path: FirestoreDocumentPath
+  ): IO[FirestoreClientError, Chunk[FirestoreDocument]] =
+    ZIO.succeed {
+      listed = listed :+ path
+    } *> listResult *> ZIO.succeed(listedDocuments)

--- a/apps/api/infrastructure/src/test/scala/morecat/infrastructure/firestore/FirestoreDocumentModelSpec.scala
+++ b/apps/api/infrastructure/src/test/scala/morecat/infrastructure/firestore/FirestoreDocumentModelSpec.scala
@@ -1,0 +1,44 @@
+package morecat.infrastructure.firestore
+
+import morecat.domain.*
+import zio.test.*
+
+object FirestoreDocumentModelSpec extends ZIOSpecDefault:
+
+  private val articleId =
+    ArticleId.fromString("018f4edc-1f5a-7c4b-aef9-000000000001")
+  private val slug =
+    Slug.applyUnsafe("hello-world")
+
+  def spec = suite("FirestoreDocumentModel")(
+    test("renders document paths as slash-separated Firestore paths") {
+      assertTrue(
+        FirestoreDocumentPath("articles", articleId.asString, "events", "1").asString ==
+          s"articles/${articleId.asString}/events/1"
+      )
+    },
+    test("builds the article event document path from articleId and seq") {
+      assertTrue(
+        FirestoreDocumentModel.articleEventPath(articleId, seq = 1L) ==
+          FirestoreDocumentPath("articles", articleId.asString, "events", "1")
+      )
+    },
+    test("builds the slug reservation document path from slug") {
+      assertTrue(
+        FirestoreDocumentModel.slugReservationPath(slug) ==
+          FirestoreDocumentPath("slugs", "hello-world")
+      )
+    },
+    test("stores article events as a JSON payload field") {
+      assertTrue(
+        FirestoreDocumentModel.articleEventData("""{"eventType":"ArticlePublished"}""") ==
+          Map("json" -> """{"eventType":"ArticlePublished"}""")
+      )
+    },
+    test("stores slug reservations as an articleId field") {
+      assertTrue(
+        FirestoreDocumentModel.slugReservationData(articleId) ==
+          Map("articleId" -> articleId.asString)
+      )
+    },
+  )


### PR DESCRIPTION
## Summary

- Add a `FirestoreDocumentModel` for Firestore document paths and stored field names.
- Add a `FirestoreDocumentClient` boundary plus `FirestoreClientEventStoreBackend` adapter.
- Refactor `FirestoreArticleEventStore` to write through path/data based document creation while preserving caller-specific conflict mapping.
- Cover transaction delegation, conflict mapping, load parsing, invalid seq ids, missing JSON payloads, and client unavailability.

## Why

This continues `docs/slice-1-plan.md` task 2 by preparing the infrastructure boundary for a real Firestore JVM SDK implementation without coupling event-store behavior tests directly to the Google SDK. The next step can implement the thin SDK-backed `FirestoreDocumentClient` against the same contract.

## Validation

- `nix develop -c sbt -batch -no-colors scalafmtCheckAll clean`
- `nix develop -c sbt -batch -no-colors coverage domain/test application/test infrastructure/test coverageAggregate`

Coverage remained at 100% statement / 100% branch.