### PR TITLE
feat(api): add google firestore document client

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,14 +52,13 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-sbt-
 
-      - name: Format check, compile, test & coverage (apps/api)
+      - name: Format check & clean (apps/api)
         run: |
           nix develop .#scala --command bash -c 'cd apps/api && sbt -batch -no-colors scalafmtCheckAll clean'
-          nix develop .#scala --command bash -c 'cd apps/api && sbt -batch -no-colors coverage domain/test application/test infrastructure/test coverageAggregate'
 
-      - name: Firestore emulator integration tests (apps/api)
+      - name: Unit, Firestore integration & coverage (apps/api)
         run: |
-          nix develop .#scala --command bash -c 'cd apps/api && firebase emulators:exec --only firestore --project demo-morecat "sbt -batch -no-colors \"infrastructure / FirestoreIntegration / test\""'
+          nix develop .#scala --command bash -c 'cd apps/api && firebase emulators:exec --only firestore --project demo-morecat "sbt -batch -no-colors coverage domain/test application/test infrastructure/test \"infrastructure / FirestoreIntegration / test\" coverageAggregate"'
 
       - name: Upload coverage report
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,8 @@ jobs:
           path: |
             ~/.sbt
             ~/.cache/coursier
-          key: ${{ runner.os }}-sbt-${{ hashFiles('apps/api/build.sbt', 'apps/api/project/build.properties', 'apps/api/project/plugins.sbt', 'apps/api/.scalafmt.conf') }}
+            ~/.cache/firebase/emulators
+          key: ${{ runner.os }}-sbt-${{ hashFiles('apps/api/build.sbt', 'apps/api/project/build.properties', 'apps/api/project/plugins.sbt', 'apps/api/.scalafmt.conf', 'apps/api/firebase.json', 'flake.lock') }}
           restore-keys: |
             ${{ runner.os }}-sbt-
 
@@ -55,6 +56,10 @@ jobs:
         run: |
           nix develop .#scala --command bash -c 'cd apps/api && sbt -batch -no-colors scalafmtCheckAll clean'
           nix develop .#scala --command bash -c 'cd apps/api && sbt -batch -no-colors coverage domain/test application/test infrastructure/test coverageAggregate'
+
+      - name: Firestore emulator integration tests (apps/api)
+        run: |
+          nix develop .#scala --command bash -c 'cd apps/api && firebase emulators:exec --only firestore --project demo-morecat "sbt -batch -no-colors \"infrastructure / FirestoreIntegration / test\""'
 
       - name: Upload coverage report
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,8 @@ result-*
 # Env (各 app スコープ。秘匿情報を含むため深さを問わず untracked に)
 .env.local
 .env.*.local
+
+# Firebase emulator logs
+/apps/api/firebase-debug.log
+/apps/api/firestore-debug.log
+/apps/api/ui-debug.log

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@
 
 ## Build, Test, and Development Commands
 - 開発環境: ルートで `nix develop`（flake で JDK 25 / sbt / Node / Rust を固定。Scala 3.8 系は JDK 17+ 必須なので JDK は nix で揃える）。以降のコマンドは dev shell 内で実行する。
-- API(Scala): sbt ビルドルートは `apps/api`。`cd apps/api` してから `sbt compile` / `sbt test`。集約カバレッジ取得は `sbt clean` 後に `sbt coverage domain/test application/test infrastructure/test coverageAggregate`（HTML は `target/scala-*/scoverage-report/`）。純粋ドメインだけは `sbt domain/test`。`api/run` 等は今後追加。
+- API(Scala): sbt ビルドルートは `apps/api`。`cd apps/api` してから `sbt compile` / `sbt test`。集約カバレッジ取得は `sbt clean` 後に `sbt coverage domain/test application/test infrastructure/test coverageAggregate`（HTML は `target/scala-*/scoverage-report/`）。純粋ドメインだけは `sbt domain/test`。Firestore エミュレータ統合テストは `firebase emulators:exec --only firestore --project demo-morecat 'sbt -batch -no-colors "infrastructure / FirestoreIntegration / test"'`。`api/run` 等は今後追加。
 - RMU(Rust): `cd apps/rmu` で `cargo build` / `cargo test`（実装はタスク3以降）。
 - UI: `apps/ui` で `pnpm install`、各 app で `pnpm dev` / `pnpm build` / `pnpm test` / `pnpm lint`。
 - 型生成: API の OpenAPI から `packages/api-client` を再生成（`pnpm gen:api`）。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@
 
 ## Build, Test, and Development Commands
 - 開発環境: ルートで `nix develop`（flake で JDK 25 / sbt / Node / Rust を固定。Scala 3.8 系は JDK 17+ 必須なので JDK は nix で揃える）。以降のコマンドは dev shell 内で実行する。
-- API(Scala): sbt ビルドルートは `apps/api`。`cd apps/api` してから `sbt compile` / `sbt test`。集約カバレッジ取得は `sbt clean` 後に `sbt coverage domain/test application/test infrastructure/test coverageAggregate`（HTML は `target/scala-*/scoverage-report/`）。純粋ドメインだけは `sbt domain/test`。Firestore エミュレータ統合テストは `firebase emulators:exec --only firestore --project demo-morecat 'sbt -batch -no-colors "infrastructure / FirestoreIntegration / test"'`。`api/run` 等は今後追加。
+- API(Scala): sbt ビルドルートは `apps/api`。`cd apps/api` してから `sbt compile` / `sbt test`。集約カバレッジ取得は `sbt clean` 後、Firestore エミュレータ内で `firebase emulators:exec --only firestore --project demo-morecat 'sbt -batch -no-colors coverage domain/test application/test infrastructure/test "infrastructure / FirestoreIntegration / test" coverageAggregate'`（HTML は `target/scala-*/scoverage-report/`）。純粋ドメインだけは `sbt domain/test`。エミュレータ統合テストだけなら `firebase emulators:exec --only firestore --project demo-morecat 'sbt -batch -no-colors "infrastructure / FirestoreIntegration / test"'`。`api/run` 等は今後追加。
 - RMU(Rust): `cd apps/rmu` で `cargo build` / `cargo test`（実装はタスク3以降）。
 - UI: `apps/ui` で `pnpm install`、各 app で `pnpm dev` / `pnpm build` / `pnpm test` / `pnpm lint`。
 - 型生成: API の OpenAPI から `packages/api-client` を再生成（`pnpm gen:api`）。

--- a/apps/api/application/src/main/scala/morecat/application/ArticleCommandService.scala
+++ b/apps/api/application/src/main/scala/morecat/application/ArticleCommandService.scala
@@ -92,8 +92,9 @@ final class ArticleCommandService(store: ArticleEventStore, clock: ServerClock):
 
   private def toCommandError(error: EventStoreError): CommandError =
     error match
-      case EventStoreError.SlugAlreadyReserved => CommandError.SlugConflict
-      case EventStoreError.VersionConflict     => CommandError.VersionConflict
-      case EventStoreError.PermissionDenied(_) => CommandError.StoreFailure
-      case EventStoreError.InvalidArgument(_)  => CommandError.StoreFailure
-      case EventStoreError.Unavailable(_)      => CommandError.StoreUnavailable
+      case EventStoreError.SlugAlreadyReserved   => CommandError.SlugConflict
+      case EventStoreError.VersionConflict       => CommandError.VersionConflict
+      case EventStoreError.FailedPrecondition(_) => CommandError.StoreFailure
+      case EventStoreError.PermissionDenied(_)   => CommandError.StoreFailure
+      case EventStoreError.InvalidArgument(_)    => CommandError.StoreFailure
+      case EventStoreError.Unavailable(_)        => CommandError.StoreUnavailable

--- a/apps/api/application/src/main/scala/morecat/application/ArticleCommandService.scala
+++ b/apps/api/application/src/main/scala/morecat/application/ArticleCommandService.scala
@@ -20,6 +20,7 @@ enum CommandError:
   case SlugConflict
   case VersionConflict
   case ArticleNotFound
+  case StoreFailure
   case StoreUnavailable
 
 enum PublishResult:
@@ -93,4 +94,6 @@ final class ArticleCommandService(store: ArticleEventStore, clock: ServerClock):
     error match
       case EventStoreError.SlugAlreadyReserved => CommandError.SlugConflict
       case EventStoreError.VersionConflict     => CommandError.VersionConflict
+      case EventStoreError.PermissionDenied(_) => CommandError.StoreFailure
+      case EventStoreError.InvalidArgument(_)  => CommandError.StoreFailure
       case EventStoreError.Unavailable(_)      => CommandError.StoreUnavailable

--- a/apps/api/application/src/main/scala/morecat/application/ArticlePorts.scala
+++ b/apps/api/application/src/main/scala/morecat/application/ArticlePorts.scala
@@ -6,6 +6,7 @@ import zio.*
 enum EventStoreError:
   case SlugAlreadyReserved
   case VersionConflict
+  case FailedPrecondition(message: String)
   case PermissionDenied(message: String)
   case InvalidArgument(message: String)
   case Unavailable(message: String)

--- a/apps/api/application/src/main/scala/morecat/application/ArticlePorts.scala
+++ b/apps/api/application/src/main/scala/morecat/application/ArticlePorts.scala
@@ -6,6 +6,8 @@ import zio.*
 enum EventStoreError:
   case SlugAlreadyReserved
   case VersionConflict
+  case PermissionDenied(message: String)
+  case InvalidArgument(message: String)
   case Unavailable(message: String)
 
 trait ArticleEventStore:

--- a/apps/api/application/src/test/scala/morecat/application/ArticleCommandServiceSpec.scala
+++ b/apps/api/application/src/test/scala/morecat/application/ArticleCommandServiceSpec.scala
@@ -119,6 +119,30 @@ object ArticleCommandServiceSpec extends ZIOSpecDefault:
           fails(equalTo(CommandError.StoreUnavailable)),
         )
       },
+      test("maps store permission failures to non-retryable StoreFailure") {
+        val store = RecordingStore(
+          loadResults = List(ZIO.fail(EventStoreError.PermissionDenied("iam denied")))
+        )
+        val service = ArticleCommandService(store, FixedClock(123L))
+
+        assertZIO(
+          service.createDraft(CreateDraftCommand(articleId, "hello-world", "Hello", "body")).exit
+        )(
+          fails(equalTo(CommandError.StoreFailure)),
+        )
+      },
+      test("maps invalid store arguments to non-retryable StoreFailure") {
+        val store = RecordingStore(
+          createDraftResult = ZIO.fail(EventStoreError.InvalidArgument("bad request"))
+        )
+        val service = ArticleCommandService(store, FixedClock(123L))
+
+        assertZIO(
+          service.createDraft(CreateDraftCommand(articleId, "hello-world", "Hello", "body")).exit
+        )(
+          fails(equalTo(CommandError.StoreFailure)),
+        )
+      },
       test("rejects invalid slug before touching the store") {
         val store = RecordingStore()
         val service = ArticleCommandService(store, FixedClock(123L))

--- a/apps/api/application/src/test/scala/morecat/application/ArticleCommandServiceSpec.scala
+++ b/apps/api/application/src/test/scala/morecat/application/ArticleCommandServiceSpec.scala
@@ -143,6 +143,18 @@ object ArticleCommandServiceSpec extends ZIOSpecDefault:
           fails(equalTo(CommandError.StoreFailure)),
         )
       },
+      test("maps failed store preconditions to non-retryable StoreFailure") {
+        val store = RecordingStore(
+          createDraftResult = ZIO.fail(EventStoreError.FailedPrecondition("precondition failed"))
+        )
+        val service = ArticleCommandService(store, FixedClock(123L))
+
+        assertZIO(
+          service.createDraft(CreateDraftCommand(articleId, "hello-world", "Hello", "body")).exit
+        )(
+          fails(equalTo(CommandError.StoreFailure)),
+        )
+      },
       test("rejects invalid slug before touching the store") {
         val store = RecordingStore()
         val service = ArticleCommandService(store, FixedClock(123L))

--- a/apps/api/build.sbt
+++ b/apps/api/build.sbt
@@ -5,6 +5,7 @@ val scala3      = "3.8.4"
 val zioVersion  = "2.1.26"
 val ironVersion = "3.3.1"
 val zioJsonVersion = "0.9.0"
+val googleCloudFirestoreVersion = "3.43.1"
 
 ThisBuild / scalaVersion := scala3
 ThisBuild / organization := "morecat"
@@ -67,6 +68,7 @@ lazy val infrastructure = project
     libraryDependencies ++= Seq(
       "dev.zio" %% "zio"          % zioVersion,
       "dev.zio" %% "zio-json"     % zioJsonVersion,
+      "com.google.cloud" % "google-cloud-firestore" % googleCloudFirestoreVersion,
       "dev.zio" %% "zio-test"     % zioVersion % Test,
       "dev.zio" %% "zio-test-sbt" % zioVersion % Test,
     ),

--- a/apps/api/build.sbt
+++ b/apps/api/build.sbt
@@ -7,6 +7,8 @@ val ironVersion = "3.3.1"
 val zioJsonVersion = "0.9.0"
 val googleCloudFirestoreVersion = "3.43.1"
 
+lazy val FirestoreIntegration = config("firestoreIntegration") extend Test
+
 ThisBuild / scalaVersion := scala3
 ThisBuild / organization := "morecat"
 ThisBuild / version      := "0.1.0-SNAPSHOT"
@@ -63,6 +65,7 @@ lazy val application = project
 lazy val infrastructure = project
   .in(file("infrastructure"))
   .dependsOn(application)
+  .configs(FirestoreIntegration)
   .settings(
     name := "morecat-infrastructure",
     libraryDependencies ++= Seq(
@@ -73,4 +76,5 @@ lazy val infrastructure = project
       "dev.zio" %% "zio-test-sbt" % zioVersion % Test,
     ),
     testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework"),
+    inConfig(FirestoreIntegration)(Defaults.testSettings),
   )

--- a/apps/api/firebase.json
+++ b/apps/api/firebase.json
@@ -1,0 +1,12 @@
+{
+  "firestore": {
+    "rules": "firestore.rules"
+  },
+  "emulators": {
+    "firestore": {
+      "host": "127.0.0.1",
+      "port": 8080
+    },
+    "singleProjectMode": true
+  }
+}

--- a/apps/api/firestore.rules
+++ b/apps/api/firestore.rules
@@ -1,0 +1,9 @@
+rules_version = '2';
+
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /{document=**} {
+      allow read, write: if false;
+    }
+  }
+}

--- a/apps/api/infrastructure/src/firestoreIntegration/scala/morecat/infrastructure/firestore/GoogleFirestoreIntegrationSpec.scala
+++ b/apps/api/infrastructure/src/firestoreIntegration/scala/morecat/infrastructure/firestore/GoogleFirestoreIntegrationSpec.scala
@@ -1,0 +1,126 @@
+package morecat.infrastructure.firestore
+
+import morecat.application.EventStoreError
+import com.google.cloud.firestore.{Firestore, FirestoreOptions}
+import zio.*
+import zio.test.*
+
+import java.util.UUID
+import scala.jdk.CollectionConverters.*
+
+object GoogleFirestoreIntegrationSpec extends ZIOSpecDefault:
+
+  def spec = suite("GoogleFirestore integration")(
+    test("creates multiple documents in one transaction") {
+      withFirestore { (firestore, client) =>
+        val collection = uniqueCollection()
+        val first = FirestoreDocumentPath(collection, "first")
+        val second = FirestoreDocumentPath(collection, "second")
+
+        for
+          _ <- client.transaction { transaction =>
+            transaction
+              .create(first, Map("value" -> "one"))
+              .mapError(FirestoreEventStoreErrorMapper.create(EventStoreError.VersionConflict)) *>
+              transaction
+                .create(second, Map("value" -> "two"))
+                .mapError(FirestoreEventStoreErrorMapper.create(EventStoreError.VersionConflict))
+          }
+          firstSnapshot  <- ZIO.attemptBlocking(firestore.document(first.asString).get().get())
+          secondSnapshot <- ZIO.attemptBlocking(firestore.document(second.asString).get().get())
+        yield assertTrue(
+          firstSnapshot.exists(),
+          firstSnapshot.getString("value") == "one",
+          secondSnapshot.exists(),
+          secondSnapshot.getString("value") == "two",
+        )
+      }
+    },
+    test("maps an existing document to the caller supplied error") {
+      withFirestore { (firestore, client) =>
+        val path = FirestoreDocumentPath(uniqueCollection(), "existing")
+
+        for
+          _ <- ZIO.attemptBlocking(
+            firestore.document(path.asString).set(Map("value" -> "existing").asJava).get()
+          )
+          exit <- client
+            .transaction(
+              _.create(path, Map("value" -> "new"))
+                .mapError(
+                  FirestoreEventStoreErrorMapper.create(EventStoreError.SlugAlreadyReserved)
+                )
+            )
+            .exit
+        yield assert(exit)(Assertion.fails(Assertion.equalTo(EventStoreError.SlugAlreadyReserved)))
+      }
+    },
+    test("does not commit staged creates when the callback returns an application error") {
+      withFirestore { (firestore, client) =>
+        val path = FirestoreDocumentPath(uniqueCollection(), "rolled-back")
+
+        for
+          exit <- client
+            .transaction { transaction =>
+              transaction
+                .create(path, Map("value" -> "staged"))
+                .mapError(FirestoreEventStoreErrorMapper.create(EventStoreError.VersionConflict)) *>
+                ZIO.fail(EventStoreError.VersionConflict)
+            }
+            .exit
+          snapshot <- ZIO.attemptBlocking(firestore.document(path.asString).get().get())
+        yield assertTrue(
+          exit == Exit.fail(EventStoreError.VersionConflict),
+          !snapshot.exists(),
+        )
+      }
+    },
+    test("rejects non-string fields read through the Firestore SDK") {
+      withFirestore { (firestore, client) =>
+        val collection = uniqueCollection()
+
+        for
+          _ <- ZIO.attemptBlocking(
+            firestore.collection(collection).document("1").set(Map("seq" -> Long.box(1L)).asJava).get()
+          )
+          exit <- client.listDocuments(FirestoreDocumentPath(collection)).exit
+        yield assert(exit)(
+          Assertion.fails(
+            Assertion.isSubtype[FirestoreClientError.InvalidArgument](Assertion.anything)
+          )
+        )
+      }
+    },
+  ) @@ TestAspect.sequential
+
+  private def withFirestore(
+    effect: (Firestore, FirestoreDocumentClient) => ZIO[Any, Throwable | EventStoreError, TestResult]
+  ): ZIO[Any, Throwable | EventStoreError, TestResult] =
+    ZIO.scoped {
+      ZIO
+        .acquireRelease(ZIO.attempt(createFirestore()))(firestore =>
+          ZIO.attempt(firestore.close()).orDie
+        )
+        .flatMap { firestore =>
+          effect(
+            firestore,
+            GoogleFirestoreDocumentClient(GoogleFirestoreOperations.fromFirestore(firestore)),
+          )
+        }
+    }
+
+  private def createFirestore(): Firestore =
+    val emulatorHost = sys.env.getOrElse(
+      "FIRESTORE_EMULATOR_HOST",
+      throw IllegalStateException("FIRESTORE_EMULATOR_HOST must be set")
+    )
+
+    FirestoreOptions
+      .newBuilder()
+      .setProjectId(sys.env.getOrElse("GCLOUD_PROJECT", "demo-morecat"))
+      .setEmulatorHost(emulatorHost)
+      .build()
+      .getService()
+
+  private def uniqueCollection(): String =
+    s"integration-${UUID.randomUUID()}"

--- a/apps/api/infrastructure/src/firestoreIntegration/scala/morecat/infrastructure/firestore/GoogleFirestoreIntegrationSpec.scala
+++ b/apps/api/infrastructure/src/firestoreIntegration/scala/morecat/infrastructure/firestore/GoogleFirestoreIntegrationSpec.scala
@@ -26,9 +26,14 @@ object GoogleFirestoreIntegrationSpec extends ZIOSpecDefault:
                 .create(second, Map("value" -> "two"))
                 .mapError(FirestoreEventStoreErrorMapper.create(EventStoreError.VersionConflict))
           }
+          documents <- client.listDocuments(FirestoreDocumentPath(collection))
           firstSnapshot  <- ZIO.attemptBlocking(firestore.document(first.asString).get().get())
           secondSnapshot <- ZIO.attemptBlocking(firestore.document(second.asString).get().get())
         yield assertTrue(
+          documents.map(document => document.id -> document.data).toMap == Map(
+            "first" -> Map("value" -> "one"),
+            "second" -> Map("value" -> "two"),
+          ),
           firstSnapshot.exists(),
           firstSnapshot.getString("value") == "one",
           secondSnapshot.exists(),
@@ -75,6 +80,15 @@ object GoogleFirestoreIntegrationSpec extends ZIOSpecDefault:
         )
       }
     },
+    test("preserves callback defects wrapped by the Firestore SDK") {
+      withFirestore { (_, client) =>
+        val defect = RuntimeException("callback bug")
+
+        assertZIO(client.transaction(_ => ZIO.die(defect)).exit)(
+          Assertion.dies(Assertion.equalTo(defect))
+        )
+      }
+    },
     test("rejects non-string fields read through the Firestore SDK") {
       withFirestore { (firestore, client) =>
         val collection = uniqueCollection()
@@ -94,8 +108,12 @@ object GoogleFirestoreIntegrationSpec extends ZIOSpecDefault:
   ) @@ TestAspect.sequential
 
   private def withFirestore(
-    effect: (Firestore, FirestoreDocumentClient) => ZIO[Any, Throwable | EventStoreError, TestResult]
-  ): ZIO[Any, Throwable | EventStoreError, TestResult] =
+    effect: (Firestore, FirestoreDocumentClient) => ZIO[
+      Any,
+      Throwable | EventStoreError | FirestoreClientError,
+      TestResult,
+    ]
+  ): ZIO[Any, Throwable | EventStoreError | FirestoreClientError, TestResult] =
     ZIO.scoped {
       ZIO
         .acquireRelease(ZIO.attempt(createFirestore()))(firestore =>

--- a/apps/api/infrastructure/src/firestoreIntegration/scala/morecat/infrastructure/firestore/GoogleFirestoreIntegrationSpec.scala
+++ b/apps/api/infrastructure/src/firestoreIntegration/scala/morecat/infrastructure/firestore/GoogleFirestoreIntegrationSpec.scala
@@ -60,6 +60,35 @@ object GoogleFirestoreIntegrationSpec extends ZIOSpecDefault:
         yield assert(exit)(Assertion.fails(Assertion.equalTo(EventStoreError.SlugAlreadyReserved)))
       }
     },
+    test("maps one of two concurrent creates to the caller supplied error") {
+      withTwoClients { (firstClient, secondClient) =>
+        val path = FirestoreDocumentPath(uniqueCollection(), "contended")
+
+        for
+          ready <- Ref.make(0)
+          start <- Promise.make[Nothing, Unit]
+          create = (client: FirestoreDocumentClient) =>
+            client.transaction { transaction =>
+              for
+                readyCount <- ready.updateAndGet(_ + 1)
+                _ <- ZIO.when(readyCount == 2)(start.succeed(()))
+                _ <- start.await.timeoutFail(
+                  EventStoreError.Unavailable("concurrent transaction callback did not start")
+                )(10.seconds)
+                _ <- transaction
+                  .create(path, Map("value" -> "created"))
+                  .mapError(
+                    FirestoreEventStoreErrorMapper.create(EventStoreError.SlugAlreadyReserved)
+                  )
+              yield ()
+            }
+          exits <- ZIO.collectAllPar(List(create(firstClient).exit, create(secondClient).exit))
+        yield assertTrue(
+          exits.count(_ == Exit.succeed(())) == 1,
+          exits.count(_ == Exit.fail(EventStoreError.SlugAlreadyReserved)) == 1,
+        )
+      }
+    },
     test("does not commit staged creates when the callback returns an application error") {
       withFirestore { (firestore, client) =>
         val path = FirestoreDocumentPath(uniqueCollection(), "rolled-back")
@@ -126,6 +155,32 @@ object GoogleFirestoreIntegrationSpec extends ZIOSpecDefault:
           )
         }
     }
+
+  private def withTwoClients(
+    effect: (
+      FirestoreDocumentClient,
+      FirestoreDocumentClient,
+    ) => ZIO[Any, EventStoreError, TestResult]
+  ): ZIO[Any, Throwable | EventStoreError, TestResult] =
+    ZIO.scoped {
+      for
+        firstFirestore  <- firestoreResource
+        secondFirestore <- firestoreResource
+        result <- effect(
+          GoogleFirestoreDocumentClient(
+            GoogleFirestoreOperations.fromFirestore(firstFirestore)
+          ),
+          GoogleFirestoreDocumentClient(
+            GoogleFirestoreOperations.fromFirestore(secondFirestore)
+          ),
+        )
+      yield result
+    }
+
+  private def firestoreResource: ZIO[Scope, Throwable, Firestore] =
+    ZIO.acquireRelease(ZIO.attempt(createFirestore()))(firestore =>
+      ZIO.attempt(firestore.close()).orDie
+    )
 
   private def createFirestore(): Firestore =
     val emulatorHost = sys.env.getOrElse(

--- a/apps/api/infrastructure/src/main/scala/morecat/infrastructure/firestore/FirestoreClientEventStoreBackend.scala
+++ b/apps/api/infrastructure/src/main/scala/morecat/infrastructure/firestore/FirestoreClientEventStoreBackend.scala
@@ -42,6 +42,8 @@ final class FirestoreClientEventStoreBackend(client: FirestoreDocumentClient)
     error match
       case FirestoreClientError.AlreadyExists =>
         EventStoreError.Unavailable("unexpected Firestore create conflict")
+      case FirestoreClientError.Conflict(message) =>
+        EventStoreError.Unavailable(s"unexpected Firestore transaction conflict: $message")
       case FirestoreClientError.PermissionDenied(message) =>
         EventStoreError.Unavailable(s"firestore permission denied: $message")
       case FirestoreClientError.InvalidArgument(message) =>
@@ -59,6 +61,8 @@ private final class FirestoreClientEventStoreTransaction(tx: FirestoreDocumentTr
   ): IO[EventStoreError, Unit] =
     tx.create(path, data).mapError {
       case FirestoreClientError.AlreadyExists =>
+        alreadyExistsError
+      case FirestoreClientError.Conflict(_) =>
         alreadyExistsError
       case FirestoreClientError.PermissionDenied(message) =>
         EventStoreError.Unavailable(s"firestore permission denied: $message")

--- a/apps/api/infrastructure/src/main/scala/morecat/infrastructure/firestore/FirestoreClientEventStoreBackend.scala
+++ b/apps/api/infrastructure/src/main/scala/morecat/infrastructure/firestore/FirestoreClientEventStoreBackend.scala
@@ -42,6 +42,10 @@ final class FirestoreClientEventStoreBackend(client: FirestoreDocumentClient)
     error match
       case FirestoreClientError.AlreadyExists =>
         EventStoreError.Unavailable("unexpected Firestore create conflict")
+      case FirestoreClientError.PermissionDenied(message) =>
+        EventStoreError.Unavailable(s"firestore permission denied: $message")
+      case FirestoreClientError.InvalidArgument(message) =>
+        EventStoreError.Unavailable(s"invalid Firestore request: $message")
       case FirestoreClientError.Unavailable(message) =>
         EventStoreError.Unavailable(message)
 
@@ -54,6 +58,12 @@ private final class FirestoreClientEventStoreTransaction(tx: FirestoreDocumentTr
     alreadyExistsError: EventStoreError,
   ): IO[EventStoreError, Unit] =
     tx.create(path, data).mapError {
-      case FirestoreClientError.AlreadyExists        => alreadyExistsError
-      case FirestoreClientError.Unavailable(message) => EventStoreError.Unavailable(message)
+      case FirestoreClientError.AlreadyExists =>
+        alreadyExistsError
+      case FirestoreClientError.PermissionDenied(message) =>
+        EventStoreError.Unavailable(s"firestore permission denied: $message")
+      case FirestoreClientError.InvalidArgument(message) =>
+        EventStoreError.Unavailable(s"invalid Firestore request: $message")
+      case FirestoreClientError.Unavailable(message) =>
+        EventStoreError.Unavailable(message)
     }

--- a/apps/api/infrastructure/src/main/scala/morecat/infrastructure/firestore/FirestoreClientEventStoreBackend.scala
+++ b/apps/api/infrastructure/src/main/scala/morecat/infrastructure/firestore/FirestoreClientEventStoreBackend.scala
@@ -45,9 +45,9 @@ final class FirestoreClientEventStoreBackend(client: FirestoreDocumentClient)
       case FirestoreClientError.Conflict(message) =>
         EventStoreError.Unavailable(s"unexpected Firestore transaction conflict: $message")
       case FirestoreClientError.PermissionDenied(message) =>
-        EventStoreError.Unavailable(s"firestore permission denied: $message")
+        EventStoreError.PermissionDenied(message)
       case FirestoreClientError.InvalidArgument(message) =>
-        EventStoreError.Unavailable(s"invalid Firestore request: $message")
+        EventStoreError.InvalidArgument(message)
       case FirestoreClientError.Unavailable(message) =>
         EventStoreError.Unavailable(message)
 
@@ -65,9 +65,9 @@ private final class FirestoreClientEventStoreTransaction(tx: FirestoreDocumentTr
       case FirestoreClientError.Conflict(_) =>
         EventStoreError.VersionConflict
       case FirestoreClientError.PermissionDenied(message) =>
-        EventStoreError.Unavailable(s"firestore permission denied: $message")
+        EventStoreError.PermissionDenied(message)
       case FirestoreClientError.InvalidArgument(message) =>
-        EventStoreError.Unavailable(s"invalid Firestore request: $message")
+        EventStoreError.InvalidArgument(message)
       case FirestoreClientError.Unavailable(message) =>
         EventStoreError.Unavailable(message)
     }

--- a/apps/api/infrastructure/src/main/scala/morecat/infrastructure/firestore/FirestoreClientEventStoreBackend.scala
+++ b/apps/api/infrastructure/src/main/scala/morecat/infrastructure/firestore/FirestoreClientEventStoreBackend.scala
@@ -15,7 +15,7 @@ final class FirestoreClientEventStoreBackend(client: FirestoreDocumentClient)
   def loadEvents(articleId: ArticleId): IO[EventStoreError, Chunk[StoredFirestoreArticleEvent]] =
     client
       .listDocuments(FirestoreDocumentModel.articleEventsCollectionPath(articleId))
-      .mapError(toEventStoreError)
+      .mapError(FirestoreEventStoreErrorMapper.read)
       .flatMap { documents =>
         ZIO
           .foreach(documents) { document =>
@@ -38,19 +38,6 @@ final class FirestoreClientEventStoreBackend(client: FirestoreDocumentClient)
       .attempt(value.toLong)
       .mapError(_ => EventStoreError.Unavailable(s"invalid event seq document id: $value"))
 
-  private def toEventStoreError(error: FirestoreClientError): EventStoreError =
-    error match
-      case FirestoreClientError.AlreadyExists =>
-        EventStoreError.Unavailable("unexpected Firestore create conflict")
-      case FirestoreClientError.Conflict(message) =>
-        EventStoreError.Unavailable(s"unexpected Firestore transaction conflict: $message")
-      case FirestoreClientError.PermissionDenied(message) =>
-        EventStoreError.PermissionDenied(message)
-      case FirestoreClientError.InvalidArgument(message) =>
-        EventStoreError.InvalidArgument(message)
-      case FirestoreClientError.Unavailable(message) =>
-        EventStoreError.Unavailable(message)
-
 private final class FirestoreClientEventStoreTransaction(tx: FirestoreDocumentTransaction)
     extends FirestoreEventStoreTransaction:
 
@@ -59,15 +46,4 @@ private final class FirestoreClientEventStoreTransaction(tx: FirestoreDocumentTr
     data: Map[String, String],
     alreadyExistsError: EventStoreError,
   ): IO[EventStoreError, Unit] =
-    tx.create(path, data).mapError {
-      case FirestoreClientError.AlreadyExists =>
-        alreadyExistsError
-      case FirestoreClientError.Conflict(_) =>
-        EventStoreError.VersionConflict
-      case FirestoreClientError.PermissionDenied(message) =>
-        EventStoreError.PermissionDenied(message)
-      case FirestoreClientError.InvalidArgument(message) =>
-        EventStoreError.InvalidArgument(message)
-      case FirestoreClientError.Unavailable(message) =>
-        EventStoreError.Unavailable(message)
-    }
+    tx.create(path, data).mapError(FirestoreEventStoreErrorMapper.create(alreadyExistsError))

--- a/apps/api/infrastructure/src/main/scala/morecat/infrastructure/firestore/FirestoreClientEventStoreBackend.scala
+++ b/apps/api/infrastructure/src/main/scala/morecat/infrastructure/firestore/FirestoreClientEventStoreBackend.scala
@@ -63,7 +63,7 @@ private final class FirestoreClientEventStoreTransaction(tx: FirestoreDocumentTr
       case FirestoreClientError.AlreadyExists =>
         alreadyExistsError
       case FirestoreClientError.Conflict(_) =>
-        alreadyExistsError
+        EventStoreError.VersionConflict
       case FirestoreClientError.PermissionDenied(message) =>
         EventStoreError.Unavailable(s"firestore permission denied: $message")
       case FirestoreClientError.InvalidArgument(message) =>

--- a/apps/api/infrastructure/src/main/scala/morecat/infrastructure/firestore/FirestoreDocumentClient.scala
+++ b/apps/api/infrastructure/src/main/scala/morecat/infrastructure/firestore/FirestoreDocumentClient.scala
@@ -7,6 +7,7 @@ final case class FirestoreDocument(id: String, data: Map[String, String])
 
 enum FirestoreClientError:
   case AlreadyExists
+  case Conflict(message: String)
   case PermissionDenied(message: String)
   case InvalidArgument(message: String)
   case Unavailable(message: String)

--- a/apps/api/infrastructure/src/main/scala/morecat/infrastructure/firestore/FirestoreDocumentClient.scala
+++ b/apps/api/infrastructure/src/main/scala/morecat/infrastructure/firestore/FirestoreDocumentClient.scala
@@ -7,6 +7,8 @@ final case class FirestoreDocument(id: String, data: Map[String, String])
 
 enum FirestoreClientError:
   case AlreadyExists
+  case PermissionDenied(message: String)
+  case InvalidArgument(message: String)
   case Unavailable(message: String)
 
 trait FirestoreDocumentClient:

--- a/apps/api/infrastructure/src/main/scala/morecat/infrastructure/firestore/FirestoreDocumentClient.scala
+++ b/apps/api/infrastructure/src/main/scala/morecat/infrastructure/firestore/FirestoreDocumentClient.scala
@@ -8,6 +8,7 @@ final case class FirestoreDocument(id: String, data: Map[String, String])
 enum FirestoreClientError:
   case AlreadyExists
   case Conflict(message: String)
+  case FailedPrecondition(message: String)
   case PermissionDenied(message: String)
   case InvalidArgument(message: String)
   case Unavailable(message: String)

--- a/apps/api/infrastructure/src/main/scala/morecat/infrastructure/firestore/FirestoreEventStoreErrorMapper.scala
+++ b/apps/api/infrastructure/src/main/scala/morecat/infrastructure/firestore/FirestoreEventStoreErrorMapper.scala
@@ -10,6 +10,8 @@ private[firestore] object FirestoreEventStoreErrorMapper:
     error match
       case FirestoreClientError.AlreadyExists | FirestoreClientError.Conflict(_) =>
         EventStoreError.VersionConflict
+      case FirestoreClientError.FailedPrecondition(message) =>
+        EventStoreError.FailedPrecondition(message)
       case FirestoreClientError.PermissionDenied(message) =>
         EventStoreError.PermissionDenied(message)
       case FirestoreClientError.InvalidArgument(message) =>
@@ -23,6 +25,8 @@ private[firestore] object FirestoreEventStoreErrorMapper:
         EventStoreError.Unavailable("unexpected Firestore create conflict")
       case FirestoreClientError.Conflict(message) =>
         EventStoreError.Unavailable(s"unexpected Firestore transaction conflict: $message")
+      case FirestoreClientError.FailedPrecondition(message) =>
+        EventStoreError.FailedPrecondition(message)
       case FirestoreClientError.PermissionDenied(message) =>
         EventStoreError.PermissionDenied(message)
       case FirestoreClientError.InvalidArgument(message) =>
@@ -38,6 +42,8 @@ private[firestore] object FirestoreEventStoreErrorMapper:
         alreadyExistsError
       case FirestoreClientError.Conflict(_) =>
         EventStoreError.VersionConflict
+      case FirestoreClientError.FailedPrecondition(message) =>
+        EventStoreError.FailedPrecondition(message)
       case FirestoreClientError.PermissionDenied(message) =>
         EventStoreError.PermissionDenied(message)
       case FirestoreClientError.InvalidArgument(message) =>

--- a/apps/api/infrastructure/src/main/scala/morecat/infrastructure/firestore/FirestoreEventStoreErrorMapper.scala
+++ b/apps/api/infrastructure/src/main/scala/morecat/infrastructure/firestore/FirestoreEventStoreErrorMapper.scala
@@ -1,0 +1,46 @@
+package morecat.infrastructure.firestore
+
+import morecat.application.EventStoreError
+
+private[firestore] object FirestoreEventStoreErrorMapper:
+  def transaction(error: Throwable): EventStoreError =
+    transaction(GoogleFirestoreErrorMapper.toClientError(error))
+
+  def transaction(error: FirestoreClientError): EventStoreError =
+    error match
+      case FirestoreClientError.AlreadyExists | FirestoreClientError.Conflict(_) =>
+        EventStoreError.VersionConflict
+      case FirestoreClientError.PermissionDenied(message) =>
+        EventStoreError.PermissionDenied(message)
+      case FirestoreClientError.InvalidArgument(message) =>
+        EventStoreError.InvalidArgument(message)
+      case FirestoreClientError.Unavailable(message) =>
+        EventStoreError.Unavailable(message)
+
+  def read(error: FirestoreClientError): EventStoreError =
+    error match
+      case FirestoreClientError.AlreadyExists =>
+        EventStoreError.Unavailable("unexpected Firestore create conflict")
+      case FirestoreClientError.Conflict(message) =>
+        EventStoreError.Unavailable(s"unexpected Firestore transaction conflict: $message")
+      case FirestoreClientError.PermissionDenied(message) =>
+        EventStoreError.PermissionDenied(message)
+      case FirestoreClientError.InvalidArgument(message) =>
+        EventStoreError.InvalidArgument(message)
+      case FirestoreClientError.Unavailable(message) =>
+        EventStoreError.Unavailable(message)
+
+  def create(
+    alreadyExistsError: EventStoreError
+  )(error: FirestoreClientError): EventStoreError =
+    error match
+      case FirestoreClientError.AlreadyExists =>
+        alreadyExistsError
+      case FirestoreClientError.Conflict(_) =>
+        EventStoreError.VersionConflict
+      case FirestoreClientError.PermissionDenied(message) =>
+        EventStoreError.PermissionDenied(message)
+      case FirestoreClientError.InvalidArgument(message) =>
+        EventStoreError.InvalidArgument(message)
+      case FirestoreClientError.Unavailable(message) =>
+        EventStoreError.Unavailable(message)

--- a/apps/api/infrastructure/src/main/scala/morecat/infrastructure/firestore/GoogleFirestoreDocumentClient.scala
+++ b/apps/api/infrastructure/src/main/scala/morecat/infrastructure/firestore/GoogleFirestoreDocumentClient.scala
@@ -1,0 +1,105 @@
+package morecat.infrastructure.firestore
+
+import morecat.application.EventStoreError
+import com.google.cloud.firestore.{Firestore, QueryDocumentSnapshot, Transaction}
+import zio.*
+
+import scala.jdk.CollectionConverters.*
+
+final class GoogleFirestoreDocumentClient(operations: GoogleFirestoreOperations)
+    extends FirestoreDocumentClient:
+
+  def transaction[A](
+    effect: FirestoreDocumentTransaction => IO[EventStoreError, A]
+  ): IO[EventStoreError, A] =
+    ZIO
+      .attemptBlocking {
+        operations.runTransaction { transaction =>
+          Unsafe.unsafe { implicit unsafe =>
+            Runtime.default.unsafe
+              .run(effect(GoogleFirestoreDocumentTransaction(transaction)).either)
+              .getOrThrowFiberFailure()
+          }
+        }
+      }
+      .mapError(toEventStoreError)
+      .flatMap(ZIO.fromEither)
+
+  def listDocuments(
+    path: FirestoreDocumentPath
+  ): IO[FirestoreClientError, Chunk[FirestoreDocument]] =
+    ZIO
+      .attemptBlocking(operations.listDocuments(path))
+      .mapError(GoogleFirestoreErrorMapper.toClientError)
+
+  private def toEventStoreError(error: Throwable): EventStoreError =
+    GoogleFirestoreErrorMapper.toClientError(error) match
+      case FirestoreClientError.AlreadyExists =>
+        EventStoreError.Unavailable("unexpected Firestore document conflict")
+      case FirestoreClientError.Unavailable(message) =>
+        EventStoreError.Unavailable(message)
+
+private final class GoogleFirestoreDocumentTransaction(
+  transaction: GoogleFirestoreTransactionOperations
+) extends FirestoreDocumentTransaction:
+
+  def create(
+    path: FirestoreDocumentPath,
+    data: Map[String, String]
+  ): IO[FirestoreClientError, Unit] =
+    ZIO
+      .attemptBlocking(transaction.create(path, data))
+      .mapError(GoogleFirestoreErrorMapper.toClientError)
+
+trait GoogleFirestoreOperations:
+  def runTransaction[A](callback: GoogleFirestoreTransactionOperations => A): A
+  def listDocuments(path: FirestoreDocumentPath): Chunk[FirestoreDocument]
+
+trait GoogleFirestoreTransactionOperations:
+  def create(path: FirestoreDocumentPath, data: Map[String, String]): Unit
+
+// $COVERAGE-OFF$
+object GoogleFirestoreOperations:
+  def fromFirestore(firestore: Firestore): GoogleFirestoreOperations =
+    LiveGoogleFirestoreOperations(firestore)
+
+private final class LiveGoogleFirestoreOperations(firestore: Firestore)
+    extends GoogleFirestoreOperations:
+
+  def runTransaction[A](callback: GoogleFirestoreTransactionOperations => A): A =
+    firestore
+      .runTransaction(
+        new Transaction.Function[A]:
+          def updateCallback(transaction: Transaction): A =
+            callback(LiveGoogleFirestoreTransactionOperations(firestore, transaction))
+      )
+      .get()
+
+  def listDocuments(path: FirestoreDocumentPath): Chunk[FirestoreDocument] =
+    Chunk.fromIterable(
+      firestore
+        .collection(path.asString)
+        .get()
+        .get()
+        .getDocuments
+        .asScala
+        .map(toDocument)
+    )
+
+  private def toDocument(snapshot: QueryDocumentSnapshot): FirestoreDocument =
+    FirestoreDocument(
+      snapshot.getId,
+      snapshot.getData.asScala.collect { case (key, value: String) =>
+        key -> value
+      }.toMap,
+    )
+
+private final class LiveGoogleFirestoreTransactionOperations(
+  firestore: Firestore,
+  transaction: Transaction,
+) extends GoogleFirestoreTransactionOperations:
+
+  def create(path: FirestoreDocumentPath, data: Map[String, String]): Unit =
+    val _ = transaction.create(firestore.document(path.asString), data.asJava)
+    ()
+// $COVERAGE-ON$

--- a/apps/api/infrastructure/src/main/scala/morecat/infrastructure/firestore/GoogleFirestoreDocumentClient.scala
+++ b/apps/api/infrastructure/src/main/scala/morecat/infrastructure/firestore/GoogleFirestoreDocumentClient.scala
@@ -52,9 +52,9 @@ final class GoogleFirestoreDocumentClient(operations: GoogleFirestoreOperations)
       case FirestoreClientError.Conflict(_) =>
         EventStoreError.VersionConflict
       case FirestoreClientError.PermissionDenied(message) =>
-        EventStoreError.Unavailable(s"firestore permission denied: $message")
+        EventStoreError.PermissionDenied(message)
       case FirestoreClientError.InvalidArgument(message) =>
-        EventStoreError.Unavailable(s"invalid Firestore request: $message")
+        EventStoreError.InvalidArgument(message)
       case FirestoreClientError.Unavailable(message) =>
         EventStoreError.Unavailable(message)
 

--- a/apps/api/infrastructure/src/main/scala/morecat/infrastructure/firestore/GoogleFirestoreDocumentClient.scala
+++ b/apps/api/infrastructure/src/main/scala/morecat/infrastructure/firestore/GoogleFirestoreDocumentClient.scala
@@ -102,7 +102,6 @@ trait GoogleFirestoreTransactionOperations:
   def create(path: FirestoreDocumentPath, data: Map[String, String]): Unit
   def commitCreates(): Unit
 
-// $COVERAGE-OFF$
 object GoogleFirestoreOperations:
   def fromFirestore(firestore: Firestore): GoogleFirestoreOperations =
     LiveGoogleFirestoreOperations(firestore)
@@ -160,4 +159,3 @@ private final class LiveGoogleFirestoreTransactionOperations(
     stagedCreates.foreach { case (path, data) =>
       val _ = transaction.create(firestore.document(path.asString), data.asJava)
     }
-// $COVERAGE-ON$

--- a/apps/api/infrastructure/src/main/scala/morecat/infrastructure/firestore/GoogleFirestoreDocumentClient.scala
+++ b/apps/api/infrastructure/src/main/scala/morecat/infrastructure/firestore/GoogleFirestoreDocumentClient.scala
@@ -1,7 +1,7 @@
 package morecat.infrastructure.firestore
 
 import morecat.application.EventStoreError
-import com.google.cloud.firestore.{Firestore, QueryDocumentSnapshot, Transaction}
+import com.google.cloud.firestore.{Firestore, Transaction}
 import io.grpc.Status
 import zio.*
 
@@ -53,6 +53,28 @@ final class GoogleFirestoreDocumentClient(operations: GoogleFirestoreOperations)
     ZIO
       .attemptBlocking(operations.listDocuments(path))
       .mapError(GoogleFirestoreErrorMapper.toClientError)
+
+private[firestore] object GoogleFirestoreDocumentDecoder:
+  def decode(id: String, data: Map[String, Object]): FirestoreDocument =
+    FirestoreDocument(
+      id,
+      data.map {
+        case (key, value: String) => key -> value
+        case (key, null)          => throw invalidFieldType(id, key, "null")
+        case (key, value)         => throw invalidFieldType(id, key, value.getClass.getName)
+      },
+    )
+
+  private def invalidFieldType(
+    documentId: String,
+    field: String,
+    actualType: String,
+  ): Throwable =
+    Status.INVALID_ARGUMENT
+      .withDescription(
+        s"Firestore document $documentId field $field must be a string, found $actualType"
+      )
+      .asRuntimeException()
 
 private final case class TransactionCallbackDefect(cause: Throwable) extends RuntimeException(cause)
 
@@ -110,15 +132,9 @@ private final class LiveGoogleFirestoreOperations(firestore: Firestore)
         .get()
         .getDocuments
         .asScala
-        .map(toDocument)
-    )
-
-  private def toDocument(snapshot: QueryDocumentSnapshot): FirestoreDocument =
-    FirestoreDocument(
-      snapshot.getId,
-      snapshot.getData.asScala.collect { case (key, value: String) =>
-        key -> value
-      }.toMap,
+        .map(snapshot =>
+          GoogleFirestoreDocumentDecoder.decode(snapshot.getId, snapshot.getData.asScala.toMap)
+        )
     )
 
 private final class LiveGoogleFirestoreTransactionOperations(

--- a/apps/api/infrastructure/src/main/scala/morecat/infrastructure/firestore/GoogleFirestoreDocumentClient.scala
+++ b/apps/api/infrastructure/src/main/scala/morecat/infrastructure/firestore/GoogleFirestoreDocumentClient.scala
@@ -2,8 +2,10 @@ package morecat.infrastructure.firestore
 
 import morecat.application.EventStoreError
 import com.google.cloud.firestore.{Firestore, QueryDocumentSnapshot, Transaction}
+import io.grpc.Status
 import zio.*
 
+import scala.collection.mutable
 import scala.jdk.CollectionConverters.*
 
 final class GoogleFirestoreDocumentClient(operations: GoogleFirestoreOperations)
@@ -16,9 +18,15 @@ final class GoogleFirestoreDocumentClient(operations: GoogleFirestoreOperations)
       .attemptBlocking {
         operations.runTransaction { transaction =>
           Unsafe.unsafe { implicit unsafe =>
-            Runtime.default.unsafe
+            val result = Runtime.default.unsafe
               .run(effect(GoogleFirestoreDocumentTransaction(transaction)).either)
               .getOrThrowFiberFailure()
+
+            result match
+              case Right(_) => transaction.commitCreates()
+              case Left(_)  => ()
+
+            result
           }
         }
       }
@@ -57,6 +65,7 @@ trait GoogleFirestoreOperations:
 
 trait GoogleFirestoreTransactionOperations:
   def create(path: FirestoreDocumentPath, data: Map[String, String]): Unit
+  def commitCreates(): Unit
 
 // $COVERAGE-OFF$
 object GoogleFirestoreOperations:
@@ -99,7 +108,22 @@ private final class LiveGoogleFirestoreTransactionOperations(
   transaction: Transaction,
 ) extends GoogleFirestoreTransactionOperations:
 
+  private val stagedCreates =
+    mutable.ArrayBuffer.empty[(FirestoreDocumentPath, Map[String, String])]
+
   def create(path: FirestoreDocumentPath, data: Map[String, String]): Unit =
-    val _ = transaction.create(firestore.document(path.asString), data.asJava)
-    ()
+    val document = firestore.document(path.asString)
+    val snapshot = transaction.get(document).get()
+
+    if snapshot.exists() then
+      throw Status.ALREADY_EXISTS
+        .withDescription(s"Firestore document already exists: ${path.asString}")
+        .asRuntimeException()
+
+    stagedCreates += path -> data
+
+  override def commitCreates(): Unit =
+    stagedCreates.foreach { case (path, data) =>
+      val _ = transaction.create(firestore.document(path.asString), data.asJava)
+    }
 // $COVERAGE-ON$

--- a/apps/api/infrastructure/src/main/scala/morecat/infrastructure/firestore/GoogleFirestoreDocumentClient.scala
+++ b/apps/api/infrastructure/src/main/scala/morecat/infrastructure/firestore/GoogleFirestoreDocumentClient.scala
@@ -44,6 +44,8 @@ final class GoogleFirestoreDocumentClient(operations: GoogleFirestoreOperations)
     GoogleFirestoreErrorMapper.toClientError(error) match
       case FirestoreClientError.AlreadyExists =>
         EventStoreError.VersionConflict
+      case FirestoreClientError.Conflict(_) =>
+        EventStoreError.VersionConflict
       case FirestoreClientError.PermissionDenied(message) =>
         EventStoreError.Unavailable(s"firestore permission denied: $message")
       case FirestoreClientError.InvalidArgument(message) =>

--- a/apps/api/infrastructure/src/main/scala/morecat/infrastructure/firestore/GoogleFirestoreDocumentClient.scala
+++ b/apps/api/infrastructure/src/main/scala/morecat/infrastructure/firestore/GoogleFirestoreDocumentClient.scala
@@ -43,7 +43,11 @@ final class GoogleFirestoreDocumentClient(operations: GoogleFirestoreOperations)
   private def toEventStoreError(error: Throwable): EventStoreError =
     GoogleFirestoreErrorMapper.toClientError(error) match
       case FirestoreClientError.AlreadyExists =>
-        EventStoreError.Unavailable("unexpected Firestore document conflict")
+        EventStoreError.VersionConflict
+      case FirestoreClientError.PermissionDenied(message) =>
+        EventStoreError.Unavailable(s"firestore permission denied: $message")
+      case FirestoreClientError.InvalidArgument(message) =>
+        EventStoreError.Unavailable(s"invalid Firestore request: $message")
       case FirestoreClientError.Unavailable(message) =>
         EventStoreError.Unavailable(message)
 

--- a/apps/api/infrastructure/src/main/scala/morecat/infrastructure/firestore/GoogleFirestoreDocumentClient.scala
+++ b/apps/api/infrastructure/src/main/scala/morecat/infrastructure/firestore/GoogleFirestoreDocumentClient.scala
@@ -18,9 +18,14 @@ final class GoogleFirestoreDocumentClient(operations: GoogleFirestoreOperations)
       .attemptBlocking {
         operations.runTransaction { transaction =>
           Unsafe.unsafe { implicit unsafe =>
-            val result = Runtime.default.unsafe
-              .run(effect(GoogleFirestoreDocumentTransaction(transaction)).either)
-              .getOrThrowFiberFailure()
+            val result =
+              try
+                Runtime.default.unsafe
+                  .run(effect(GoogleFirestoreDocumentTransaction(transaction)).either)
+                  .getOrThrowFiberFailure()
+              catch
+                case failure: FiberFailure =>
+                  throw failure.cause.asInstanceOf[Cause[Throwable]].squash
 
             result match
               case Right(_) => transaction.commitCreates()
@@ -63,7 +68,11 @@ private final class GoogleFirestoreDocumentTransaction(
   ): IO[FirestoreClientError, Unit] =
     ZIO
       .attemptBlocking(transaction.create(path, data))
-      .mapError(GoogleFirestoreErrorMapper.toClientError)
+      .catchAll { error =>
+        GoogleFirestoreErrorMapper.abortedCause(error) match
+          case Some(cause) => ZIO.die(cause)
+          case None        => ZIO.fail(GoogleFirestoreErrorMapper.toClientError(error))
+      }
 
 trait GoogleFirestoreOperations:
   def runTransaction[A](callback: GoogleFirestoreTransactionOperations => A): A

--- a/apps/api/infrastructure/src/main/scala/morecat/infrastructure/firestore/GoogleFirestoreDocumentClient.scala
+++ b/apps/api/infrastructure/src/main/scala/morecat/infrastructure/firestore/GoogleFirestoreDocumentClient.scala
@@ -42,7 +42,7 @@ final class GoogleFirestoreDocumentClient(operations: GoogleFirestoreOperations)
         }
         .catchAll {
           case TransactionCallbackDefect(cause) => ZIO.die(cause)
-          case error                            => ZIO.fail(toEventStoreError(error))
+          case error => ZIO.fail(FirestoreEventStoreErrorMapper.transaction(error))
         }
         .flatMap(ZIO.fromEither)
     }
@@ -53,19 +53,6 @@ final class GoogleFirestoreDocumentClient(operations: GoogleFirestoreOperations)
     ZIO
       .attemptBlocking(operations.listDocuments(path))
       .mapError(GoogleFirestoreErrorMapper.toClientError)
-
-  private def toEventStoreError(error: Throwable): EventStoreError =
-    GoogleFirestoreErrorMapper.toClientError(error) match
-      case FirestoreClientError.AlreadyExists =>
-        EventStoreError.VersionConflict
-      case FirestoreClientError.Conflict(_) =>
-        EventStoreError.VersionConflict
-      case FirestoreClientError.PermissionDenied(message) =>
-        EventStoreError.PermissionDenied(message)
-      case FirestoreClientError.InvalidArgument(message) =>
-        EventStoreError.InvalidArgument(message)
-      case FirestoreClientError.Unavailable(message) =>
-        EventStoreError.Unavailable(message)
 
 private final case class TransactionCallbackDefect(cause: Throwable) extends RuntimeException(cause)
 

--- a/apps/api/infrastructure/src/main/scala/morecat/infrastructure/firestore/GoogleFirestoreDocumentClient.scala
+++ b/apps/api/infrastructure/src/main/scala/morecat/infrastructure/firestore/GoogleFirestoreDocumentClient.scala
@@ -5,6 +5,7 @@ import com.google.cloud.firestore.{Firestore, QueryDocumentSnapshot, Transaction
 import io.grpc.Status
 import zio.*
 
+import java.util.concurrent.ExecutionException
 import scala.collection.mutable
 import scala.jdk.CollectionConverters.*
 
@@ -14,29 +15,37 @@ final class GoogleFirestoreDocumentClient(operations: GoogleFirestoreOperations)
   def transaction[A](
     effect: FirestoreDocumentTransaction => IO[EventStoreError, A]
   ): IO[EventStoreError, A] =
-    ZIO
-      .attemptBlocking {
-        operations.runTransaction { transaction =>
-          Unsafe.unsafe { implicit unsafe =>
-            val result =
-              try
-                Runtime.default.unsafe
-                  .run(effect(GoogleFirestoreDocumentTransaction(transaction)).either)
-                  .getOrThrowFiberFailure()
-              catch
-                case failure: FiberFailure =>
-                  throw failure.cause.asInstanceOf[Cause[Throwable]].squash
+    ZIO.runtime[Any].flatMap { runtime =>
+      ZIO
+        .attemptBlocking {
+          operations.runTransaction { transaction =>
+            Unsafe.unsafe { implicit unsafe =>
+              val result =
+                try
+                  runtime.unsafe
+                    .run(effect(GoogleFirestoreDocumentTransaction(transaction)).either)
+                    .getOrThrowFiberFailure()
+                catch
+                  case failure: FiberFailure =>
+                    val cause = failure.cause.asInstanceOf[Cause[Throwable]].squash
+                    GoogleFirestoreErrorMapper.abortedCause(cause) match
+                      case Some(aborted) => throw aborted
+                      case None          => throw TransactionCallbackDefect(cause)
 
-            result match
-              case Right(_) => transaction.commitCreates()
-              case Left(_)  => ()
+              result match
+                case Right(_) => transaction.commitCreates()
+                case Left(_)  => ()
 
-            result
+              result
+            }
           }
         }
-      }
-      .mapError(toEventStoreError)
-      .flatMap(ZIO.fromEither)
+        .catchAll {
+          case TransactionCallbackDefect(cause) => ZIO.die(cause)
+          case error                            => ZIO.fail(toEventStoreError(error))
+        }
+        .flatMap(ZIO.fromEither)
+    }
 
   def listDocuments(
     path: FirestoreDocumentPath
@@ -57,6 +66,8 @@ final class GoogleFirestoreDocumentClient(operations: GoogleFirestoreOperations)
         EventStoreError.InvalidArgument(message)
       case FirestoreClientError.Unavailable(message) =>
         EventStoreError.Unavailable(message)
+
+private final case class TransactionCallbackDefect(cause: Throwable) extends RuntimeException(cause)
 
 private final class GoogleFirestoreDocumentTransaction(
   transaction: GoogleFirestoreTransactionOperations
@@ -91,13 +102,18 @@ private final class LiveGoogleFirestoreOperations(firestore: Firestore)
     extends GoogleFirestoreOperations:
 
   def runTransaction[A](callback: GoogleFirestoreTransactionOperations => A): A =
-    firestore
-      .runTransaction(
-        new Transaction.Function[A]:
-          def updateCallback(transaction: Transaction): A =
-            callback(LiveGoogleFirestoreTransactionOperations(firestore, transaction))
-      )
-      .get()
+    try
+      firestore
+        .runTransaction(
+          new Transaction.Function[A]:
+            def updateCallback(transaction: Transaction): A =
+              callback(LiveGoogleFirestoreTransactionOperations(firestore, transaction))
+        )
+        .get()
+    catch
+      case wrapped: ExecutionException
+          if wrapped.getCause.isInstanceOf[TransactionCallbackDefect] =>
+        throw wrapped.getCause
 
   def listDocuments(path: FirestoreDocumentPath): Chunk[FirestoreDocument] =
     Chunk.fromIterable(

--- a/apps/api/infrastructure/src/main/scala/morecat/infrastructure/firestore/GoogleFirestoreDocumentClient.scala
+++ b/apps/api/infrastructure/src/main/scala/morecat/infrastructure/firestore/GoogleFirestoreDocumentClient.scala
@@ -145,7 +145,7 @@ private final class LiveGoogleFirestoreTransactionOperations(
   private val stagedCreates =
     mutable.ArrayBuffer.empty[(FirestoreDocumentPath, Map[String, String])]
 
-  def create(path: FirestoreDocumentPath, data: Map[String, String]): Unit =
+  override def create(path: FirestoreDocumentPath, data: Map[String, String]): Unit =
     val document = firestore.document(path.asString)
     val snapshot = transaction.get(document).get()
 

--- a/apps/api/infrastructure/src/main/scala/morecat/infrastructure/firestore/GoogleFirestoreDocumentClient.scala
+++ b/apps/api/infrastructure/src/main/scala/morecat/infrastructure/firestore/GoogleFirestoreDocumentClient.scala
@@ -146,6 +146,10 @@ private final class LiveGoogleFirestoreTransactionOperations(
 
   override def create(path: FirestoreDocumentPath, data: Map[String, String]): Unit =
     val document = firestore.document(path.asString)
+    // This read puts the document in the transaction's read set: a concurrent creation
+    // makes the commit return ABORTED, so the SDK retries the callback and sees the
+    // document as existing at this read. Conflicts therefore always surface here (where
+    // callers map AlreadyExists to a domain error) and never at commitCreates().
     val snapshot = transaction.get(document).get()
 
     if snapshot.exists() then

--- a/apps/api/infrastructure/src/main/scala/morecat/infrastructure/firestore/GoogleFirestoreErrorMapper.scala
+++ b/apps/api/infrastructure/src/main/scala/morecat/infrastructure/firestore/GoogleFirestoreErrorMapper.scala
@@ -6,18 +6,34 @@ import io.grpc.{Status, StatusRuntimeException}
 import java.util.concurrent.{CompletionException, ExecutionException}
 
 object GoogleFirestoreErrorMapper:
+  def abortedCause(error: Throwable): Option[Throwable] =
+    unwrap(error) match
+      case firestoreError: FirestoreException
+          if firestoreError.getStatus.getCode == Status.Code.ABORTED =>
+        Some(firestoreError)
+      case grpcError: StatusRuntimeException
+          if grpcError.getStatus.getCode == Status.Code.ABORTED =>
+        Some(grpcError)
+      case _ =>
+        None
+
   def toClientError(error: Throwable): FirestoreClientError =
-    error match
-      case wrapped: ExecutionException if wrapped.getCause != null =>
-        toClientError(wrapped.getCause)
-      case wrapped: CompletionException if wrapped.getCause != null =>
-        toClientError(wrapped.getCause)
+    unwrap(error) match
       case firestoreError: FirestoreException =>
         toClientError(firestoreError.getStatus.getCode, messageOf(firestoreError))
       case grpcError: StatusRuntimeException =>
         toClientError(grpcError.getStatus.getCode, messageOf(grpcError))
       case other =>
         FirestoreClientError.Unavailable(messageOf(other))
+
+  private def unwrap(error: Throwable): Throwable =
+    error match
+      case wrapped: ExecutionException if wrapped.getCause != null =>
+        unwrap(wrapped.getCause)
+      case wrapped: CompletionException if wrapped.getCause != null =>
+        unwrap(wrapped.getCause)
+      case other =>
+        other
 
   private def toClientError(
     code: Status.Code,

--- a/apps/api/infrastructure/src/main/scala/morecat/infrastructure/firestore/GoogleFirestoreErrorMapper.scala
+++ b/apps/api/infrastructure/src/main/scala/morecat/infrastructure/firestore/GoogleFirestoreErrorMapper.scala
@@ -12,11 +12,26 @@ object GoogleFirestoreErrorMapper:
         toClientError(wrapped.getCause)
       case wrapped: CompletionException if wrapped.getCause != null =>
         toClientError(wrapped.getCause)
-      case firestoreError: FirestoreException
-          if firestoreError.getStatus.getCode == Status.Code.ALREADY_EXISTS =>
-        FirestoreClientError.AlreadyExists
-      case grpcError: StatusRuntimeException
-          if grpcError.getStatus.getCode == Status.Code.ALREADY_EXISTS =>
-        FirestoreClientError.AlreadyExists
+      case firestoreError: FirestoreException =>
+        toClientError(firestoreError.getStatus.getCode, messageOf(firestoreError))
+      case grpcError: StatusRuntimeException =>
+        toClientError(grpcError.getStatus.getCode, messageOf(grpcError))
       case other =>
-        FirestoreClientError.Unavailable(Option(other.getMessage).getOrElse(other.toString))
+        FirestoreClientError.Unavailable(messageOf(other))
+
+  private def toClientError(
+    code: Status.Code,
+    message: String,
+  ): FirestoreClientError =
+    code match
+      case Status.Code.ALREADY_EXISTS =>
+        FirestoreClientError.AlreadyExists
+      case Status.Code.PERMISSION_DENIED =>
+        FirestoreClientError.PermissionDenied(message)
+      case Status.Code.INVALID_ARGUMENT =>
+        FirestoreClientError.InvalidArgument(message)
+      case _ =>
+        FirestoreClientError.Unavailable(message)
+
+  private def messageOf(error: Throwable): String =
+    Option(error.getMessage).getOrElse(error.toString)

--- a/apps/api/infrastructure/src/main/scala/morecat/infrastructure/firestore/GoogleFirestoreErrorMapper.scala
+++ b/apps/api/infrastructure/src/main/scala/morecat/infrastructure/firestore/GoogleFirestoreErrorMapper.scala
@@ -42,8 +42,10 @@ object GoogleFirestoreErrorMapper:
     code match
       case Status.Code.ALREADY_EXISTS =>
         FirestoreClientError.AlreadyExists
-      case Status.Code.ABORTED | Status.Code.FAILED_PRECONDITION =>
+      case Status.Code.ABORTED =>
         FirestoreClientError.Conflict(message)
+      case Status.Code.FAILED_PRECONDITION =>
+        FirestoreClientError.FailedPrecondition(message)
       case Status.Code.PERMISSION_DENIED =>
         FirestoreClientError.PermissionDenied(message)
       case Status.Code.INVALID_ARGUMENT =>

--- a/apps/api/infrastructure/src/main/scala/morecat/infrastructure/firestore/GoogleFirestoreErrorMapper.scala
+++ b/apps/api/infrastructure/src/main/scala/morecat/infrastructure/firestore/GoogleFirestoreErrorMapper.scala
@@ -1,5 +1,6 @@
 package morecat.infrastructure.firestore
 
+import com.google.cloud.firestore.FirestoreException
 import io.grpc.{Status, StatusRuntimeException}
 
 import java.util.concurrent.{CompletionException, ExecutionException}
@@ -11,6 +12,9 @@ object GoogleFirestoreErrorMapper:
         toClientError(wrapped.getCause)
       case wrapped: CompletionException if wrapped.getCause != null =>
         toClientError(wrapped.getCause)
+      case firestoreError: FirestoreException
+          if firestoreError.getStatus.getCode == Status.Code.ALREADY_EXISTS =>
+        FirestoreClientError.AlreadyExists
       case grpcError: StatusRuntimeException
           if grpcError.getStatus.getCode == Status.Code.ALREADY_EXISTS =>
         FirestoreClientError.AlreadyExists

--- a/apps/api/infrastructure/src/main/scala/morecat/infrastructure/firestore/GoogleFirestoreErrorMapper.scala
+++ b/apps/api/infrastructure/src/main/scala/morecat/infrastructure/firestore/GoogleFirestoreErrorMapper.scala
@@ -26,6 +26,8 @@ object GoogleFirestoreErrorMapper:
     code match
       case Status.Code.ALREADY_EXISTS =>
         FirestoreClientError.AlreadyExists
+      case Status.Code.ABORTED | Status.Code.FAILED_PRECONDITION =>
+        FirestoreClientError.Conflict(message)
       case Status.Code.PERMISSION_DENIED =>
         FirestoreClientError.PermissionDenied(message)
       case Status.Code.INVALID_ARGUMENT =>

--- a/apps/api/infrastructure/src/main/scala/morecat/infrastructure/firestore/GoogleFirestoreErrorMapper.scala
+++ b/apps/api/infrastructure/src/main/scala/morecat/infrastructure/firestore/GoogleFirestoreErrorMapper.scala
@@ -1,0 +1,18 @@
+package morecat.infrastructure.firestore
+
+import io.grpc.{Status, StatusRuntimeException}
+
+import java.util.concurrent.{CompletionException, ExecutionException}
+
+object GoogleFirestoreErrorMapper:
+  def toClientError(error: Throwable): FirestoreClientError =
+    error match
+      case wrapped: ExecutionException if wrapped.getCause != null =>
+        toClientError(wrapped.getCause)
+      case wrapped: CompletionException if wrapped.getCause != null =>
+        toClientError(wrapped.getCause)
+      case grpcError: StatusRuntimeException
+          if grpcError.getStatus.getCode == Status.Code.ALREADY_EXISTS =>
+        FirestoreClientError.AlreadyExists
+      case other =>
+        FirestoreClientError.Unavailable(Option(other.getMessage).getOrElse(other.toString))

--- a/apps/api/infrastructure/src/main/scala/morecat/infrastructure/firestore/GoogleFirestoreErrorMapper.scala
+++ b/apps/api/infrastructure/src/main/scala/morecat/infrastructure/firestore/GoogleFirestoreErrorMapper.scala
@@ -24,7 +24,7 @@ object GoogleFirestoreErrorMapper:
       case grpcError: StatusRuntimeException =>
         toClientError(grpcError.getStatus.getCode, messageOf(grpcError))
       case other =>
-        FirestoreClientError.Unavailable(messageOf(other))
+        throw other
 
   private def unwrap(error: Throwable): Throwable =
     error match

--- a/apps/api/infrastructure/src/test/scala/morecat/infrastructure/firestore/FirestoreClientEventStoreBackendSpec.scala
+++ b/apps/api/infrastructure/src/test/scala/morecat/infrastructure/firestore/FirestoreClientEventStoreBackendSpec.scala
@@ -62,6 +62,52 @@ object FirestoreClientEventStoreBackendSpec extends ZIOSpecDefault:
           .exit
       )(Assertion.fails(Assertion.equalTo(EventStoreError.Unavailable("down"))))
     },
+    test("createDocument maps permission failures with an observable message") {
+      val client =
+        RecordingFirestoreDocumentClient(createResult =
+          ZIO.fail(FirestoreClientError.PermissionDenied("iam denied"))
+        )
+      val backend = FirestoreClientEventStoreBackend(client)
+
+      assertZIO(
+        backend
+          .runTransaction(
+            _.createDocument(
+              FirestoreDocumentPath("slugs", "hello-world"),
+              Map("articleId" -> articleId.asString),
+              EventStoreError.SlugAlreadyReserved,
+            )
+          )
+          .exit
+      )(
+        Assertion.fails(
+          Assertion.equalTo(EventStoreError.Unavailable("firestore permission denied: iam denied"))
+        )
+      )
+    },
+    test("createDocument maps invalid request failures with an observable message") {
+      val client =
+        RecordingFirestoreDocumentClient(createResult =
+          ZIO.fail(FirestoreClientError.InvalidArgument("bad request"))
+        )
+      val backend = FirestoreClientEventStoreBackend(client)
+
+      assertZIO(
+        backend
+          .runTransaction(
+            _.createDocument(
+              FirestoreDocumentPath("slugs", "hello-world"),
+              Map("articleId" -> articleId.asString),
+              EventStoreError.SlugAlreadyReserved,
+            )
+          )
+          .exit
+      )(
+        Assertion.fails(
+          Assertion.equalTo(EventStoreError.Unavailable("invalid Firestore request: bad request"))
+        )
+      )
+    },
     test("loadEvents reads the article events collection and returns events sorted by seq") {
       val client = RecordingFirestoreDocumentClient(
         listedDocuments = Chunk(
@@ -121,6 +167,32 @@ object FirestoreClientEventStoreBackendSpec extends ZIOSpecDefault:
 
       assertZIO(backend.loadEvents(articleId).exit)(
         Assertion.fails(Assertion.equalTo(EventStoreError.Unavailable("down")))
+      )
+    },
+    test("loadEvents maps permission failures with an observable message") {
+      val client =
+        RecordingFirestoreDocumentClient(listResult =
+          ZIO.fail(FirestoreClientError.PermissionDenied("iam denied"))
+        )
+      val backend = FirestoreClientEventStoreBackend(client)
+
+      assertZIO(backend.loadEvents(articleId).exit)(
+        Assertion.fails(
+          Assertion.equalTo(EventStoreError.Unavailable("firestore permission denied: iam denied"))
+        )
+      )
+    },
+    test("loadEvents maps invalid request failures with an observable message") {
+      val client =
+        RecordingFirestoreDocumentClient(listResult =
+          ZIO.fail(FirestoreClientError.InvalidArgument("bad request"))
+        )
+      val backend = FirestoreClientEventStoreBackend(client)
+
+      assertZIO(backend.loadEvents(articleId).exit)(
+        Assertion.fails(
+          Assertion.equalTo(EventStoreError.Unavailable("invalid Firestore request: bad request"))
+        )
       )
     },
     test("loadEvents maps unexpected AlreadyExists to Unavailable") {

--- a/apps/api/infrastructure/src/test/scala/morecat/infrastructure/firestore/FirestoreClientEventStoreBackendSpec.scala
+++ b/apps/api/infrastructure/src/test/scala/morecat/infrastructure/firestore/FirestoreClientEventStoreBackendSpec.scala
@@ -80,7 +80,7 @@ object FirestoreClientEventStoreBackendSpec extends ZIOSpecDefault:
           .exit
       )(Assertion.fails(Assertion.equalTo(EventStoreError.Unavailable("down"))))
     },
-    test("createDocument maps permission failures with an observable message") {
+    test("createDocument preserves non-retryable permission failures") {
       val client =
         RecordingFirestoreDocumentClient(createResult =
           ZIO.fail(FirestoreClientError.PermissionDenied("iam denied"))
@@ -99,11 +99,11 @@ object FirestoreClientEventStoreBackendSpec extends ZIOSpecDefault:
           .exit
       )(
         Assertion.fails(
-          Assertion.equalTo(EventStoreError.Unavailable("firestore permission denied: iam denied"))
+          Assertion.equalTo(EventStoreError.PermissionDenied("iam denied"))
         )
       )
     },
-    test("createDocument maps invalid request failures with an observable message") {
+    test("createDocument preserves non-retryable invalid arguments") {
       val client =
         RecordingFirestoreDocumentClient(createResult =
           ZIO.fail(FirestoreClientError.InvalidArgument("bad request"))
@@ -122,7 +122,7 @@ object FirestoreClientEventStoreBackendSpec extends ZIOSpecDefault:
           .exit
       )(
         Assertion.fails(
-          Assertion.equalTo(EventStoreError.Unavailable("invalid Firestore request: bad request"))
+          Assertion.equalTo(EventStoreError.InvalidArgument("bad request"))
         )
       )
     },
@@ -187,7 +187,7 @@ object FirestoreClientEventStoreBackendSpec extends ZIOSpecDefault:
         Assertion.fails(Assertion.equalTo(EventStoreError.Unavailable("down")))
       )
     },
-    test("loadEvents maps permission failures with an observable message") {
+    test("loadEvents preserves non-retryable permission failures") {
       val client =
         RecordingFirestoreDocumentClient(listResult =
           ZIO.fail(FirestoreClientError.PermissionDenied("iam denied"))
@@ -196,11 +196,11 @@ object FirestoreClientEventStoreBackendSpec extends ZIOSpecDefault:
 
       assertZIO(backend.loadEvents(articleId).exit)(
         Assertion.fails(
-          Assertion.equalTo(EventStoreError.Unavailable("firestore permission denied: iam denied"))
+          Assertion.equalTo(EventStoreError.PermissionDenied("iam denied"))
         )
       )
     },
-    test("loadEvents maps invalid request failures with an observable message") {
+    test("loadEvents preserves non-retryable invalid arguments") {
       val client =
         RecordingFirestoreDocumentClient(listResult =
           ZIO.fail(FirestoreClientError.InvalidArgument("bad request"))
@@ -209,7 +209,7 @@ object FirestoreClientEventStoreBackendSpec extends ZIOSpecDefault:
 
       assertZIO(backend.loadEvents(articleId).exit)(
         Assertion.fails(
-          Assertion.equalTo(EventStoreError.Unavailable("invalid Firestore request: bad request"))
+          Assertion.equalTo(EventStoreError.InvalidArgument("bad request"))
         )
       )
     },

--- a/apps/api/infrastructure/src/test/scala/morecat/infrastructure/firestore/FirestoreClientEventStoreBackendSpec.scala
+++ b/apps/api/infrastructure/src/test/scala/morecat/infrastructure/firestore/FirestoreClientEventStoreBackendSpec.scala
@@ -43,6 +43,24 @@ object FirestoreClientEventStoreBackendSpec extends ZIOSpecDefault:
           .exit
       )(Assertion.fails(Assertion.equalTo(EventStoreError.SlugAlreadyReserved)))
     },
+    test("createDocument maps transaction conflicts to the caller supplied conflict") {
+      val client = RecordingFirestoreDocumentClient(createResult =
+        ZIO.fail(FirestoreClientError.Conflict("transaction contention"))
+      )
+      val backend = FirestoreClientEventStoreBackend(client)
+
+      assertZIO(
+        backend
+          .runTransaction(
+            _.createDocument(
+              FirestoreDocumentPath("slugs", "hello-world"),
+              Map("articleId" -> articleId.asString),
+              EventStoreError.SlugAlreadyReserved,
+            )
+          )
+          .exit
+      )(Assertion.fails(Assertion.equalTo(EventStoreError.SlugAlreadyReserved)))
+    },
     test("createDocument maps client unavailability to EventStoreError.Unavailable") {
       val client =
         RecordingFirestoreDocumentClient(createResult =
@@ -203,6 +221,23 @@ object FirestoreClientEventStoreBackendSpec extends ZIOSpecDefault:
       assertZIO(backend.loadEvents(articleId).exit)(
         Assertion.fails(
           Assertion.equalTo(EventStoreError.Unavailable("unexpected Firestore create conflict"))
+        )
+      )
+    },
+    test("loadEvents maps unexpected transaction conflicts to Unavailable") {
+      val client =
+        RecordingFirestoreDocumentClient(listResult =
+          ZIO.fail(FirestoreClientError.Conflict("transaction contention"))
+        )
+      val backend = FirestoreClientEventStoreBackend(client)
+
+      assertZIO(backend.loadEvents(articleId).exit)(
+        Assertion.fails(
+          Assertion.equalTo(
+            EventStoreError.Unavailable(
+              "unexpected Firestore transaction conflict: transaction contention"
+            )
+          )
         )
       )
     },

--- a/apps/api/infrastructure/src/test/scala/morecat/infrastructure/firestore/FirestoreClientEventStoreBackendSpec.scala
+++ b/apps/api/infrastructure/src/test/scala/morecat/infrastructure/firestore/FirestoreClientEventStoreBackendSpec.scala
@@ -61,6 +61,28 @@ object FirestoreClientEventStoreBackendSpec extends ZIOSpecDefault:
           .exit
       )(Assertion.fails(Assertion.equalTo(EventStoreError.VersionConflict)))
     },
+    test("createDocument preserves non-retryable failed preconditions") {
+      val client = RecordingFirestoreDocumentClient(createResult =
+        ZIO.fail(FirestoreClientError.FailedPrecondition("precondition failed"))
+      )
+      val backend = FirestoreClientEventStoreBackend(client)
+
+      assertZIO(
+        backend
+          .runTransaction(
+            _.createDocument(
+              FirestoreDocumentPath("slugs", "hello-world"),
+              Map("articleId" -> articleId.asString),
+              EventStoreError.SlugAlreadyReserved,
+            )
+          )
+          .exit
+      )(
+        Assertion.fails(
+          Assertion.equalTo(EventStoreError.FailedPrecondition("precondition failed"))
+        )
+      )
+    },
     test("createDocument maps client unavailability to EventStoreError.Unavailable") {
       val client =
         RecordingFirestoreDocumentClient(createResult =
@@ -210,6 +232,18 @@ object FirestoreClientEventStoreBackendSpec extends ZIOSpecDefault:
       assertZIO(backend.loadEvents(articleId).exit)(
         Assertion.fails(
           Assertion.equalTo(EventStoreError.InvalidArgument("bad request"))
+        )
+      )
+    },
+    test("loadEvents preserves non-retryable failed preconditions") {
+      val client = RecordingFirestoreDocumentClient(listResult =
+        ZIO.fail(FirestoreClientError.FailedPrecondition("precondition failed"))
+      )
+      val backend = FirestoreClientEventStoreBackend(client)
+
+      assertZIO(backend.loadEvents(articleId).exit)(
+        Assertion.fails(
+          Assertion.equalTo(EventStoreError.FailedPrecondition("precondition failed"))
         )
       )
     },

--- a/apps/api/infrastructure/src/test/scala/morecat/infrastructure/firestore/FirestoreClientEventStoreBackendSpec.scala
+++ b/apps/api/infrastructure/src/test/scala/morecat/infrastructure/firestore/FirestoreClientEventStoreBackendSpec.scala
@@ -43,7 +43,7 @@ object FirestoreClientEventStoreBackendSpec extends ZIOSpecDefault:
           .exit
       )(Assertion.fails(Assertion.equalTo(EventStoreError.SlugAlreadyReserved)))
     },
-    test("createDocument maps transaction conflicts to the caller supplied conflict") {
+    test("createDocument maps transaction conflicts to VersionConflict") {
       val client = RecordingFirestoreDocumentClient(createResult =
         ZIO.fail(FirestoreClientError.Conflict("transaction contention"))
       )
@@ -59,7 +59,7 @@ object FirestoreClientEventStoreBackendSpec extends ZIOSpecDefault:
             )
           )
           .exit
-      )(Assertion.fails(Assertion.equalTo(EventStoreError.SlugAlreadyReserved)))
+      )(Assertion.fails(Assertion.equalTo(EventStoreError.VersionConflict)))
     },
     test("createDocument maps client unavailability to EventStoreError.Unavailable") {
       val client =

--- a/apps/api/infrastructure/src/test/scala/morecat/infrastructure/firestore/GoogleFirestoreDocumentClientSpec.scala
+++ b/apps/api/infrastructure/src/test/scala/morecat/infrastructure/firestore/GoogleFirestoreDocumentClientSpec.scala
@@ -270,7 +270,7 @@ private final class RecordingGoogleFirestoreTransactionOperations(
   operations: RecordingGoogleFirestoreOperations
 ) extends GoogleFirestoreTransactionOperations:
 
-  def create(path: FirestoreDocumentPath, data: Map[String, String]): Unit =
+  override def create(path: FirestoreDocumentPath, data: Map[String, String]): Unit =
     operations.createAttemptCount = operations.createAttemptCount + 1
     if operations.retryAbortedCreateOnce && operations.createAttemptCount == 1 then
       throw Status.ABORTED.withDescription("transaction contention").asRuntimeException()

--- a/apps/api/infrastructure/src/test/scala/morecat/infrastructure/firestore/GoogleFirestoreDocumentClientSpec.scala
+++ b/apps/api/infrastructure/src/test/scala/morecat/infrastructure/firestore/GoogleFirestoreDocumentClientSpec.scala
@@ -64,6 +64,17 @@ object GoogleFirestoreDocumentClientSpec extends ZIOSpecDefault:
         Assertion.fails(Assertion.equalTo(EventStoreError.VersionConflict))
       )
     },
+    test("transaction maps contention failures to VersionConflict") {
+      val operations = RecordingGoogleFirestoreOperations(
+        transactionFailure =
+          Some(Status.ABORTED.withDescription("transaction contention").asRuntimeException())
+      )
+      val client = GoogleFirestoreDocumentClient(operations)
+
+      assertZIO(client.transaction(_ => ZIO.succeed("unused")).exit)(
+        Assertion.fails(Assertion.equalTo(EventStoreError.VersionConflict))
+      )
+    },
     test("transaction maps permission failures with an observable message") {
       val operations = RecordingGoogleFirestoreOperations(
         transactionFailure =
@@ -143,6 +154,8 @@ object GoogleFirestoreDocumentClientSpec extends ZIOSpecDefault:
   )(error: FirestoreClientError): EventStoreError =
     error match
       case FirestoreClientError.AlreadyExists =>
+        alreadyExistsError
+      case FirestoreClientError.Conflict(_) =>
         alreadyExistsError
       case FirestoreClientError.PermissionDenied(message) =>
         EventStoreError.Unavailable(s"firestore permission denied: $message")

--- a/apps/api/infrastructure/src/test/scala/morecat/infrastructure/firestore/GoogleFirestoreDocumentClientSpec.scala
+++ b/apps/api/infrastructure/src/test/scala/morecat/infrastructure/firestore/GoogleFirestoreDocumentClientSpec.scala
@@ -1,0 +1,141 @@
+package morecat.infrastructure.firestore
+
+import morecat.application.EventStoreError
+import io.grpc.Status
+import zio.*
+import zio.test.*
+
+object GoogleFirestoreDocumentClientSpec extends ZIOSpecDefault:
+
+  private val path =
+    FirestoreDocumentPath("articles", "018f4edc-1f5a-7c4b-aef9-000000000001", "events", "1")
+  private val data = Map(
+    FirestoreDocumentModel.EventJsonField -> """{"eventType":"ArticleDrafted"}"""
+  )
+
+  def spec = suite("GoogleFirestoreDocumentClient")(
+    test("transaction delegates to Firestore operations with a transaction-only handle") {
+      val operations = RecordingGoogleFirestoreOperations()
+      val client = GoogleFirestoreDocumentClient(operations)
+
+      for result <- client.transaction { tx =>
+          tx.create(path, data)
+            .mapError(toEventStoreError(EventStoreError.VersionConflict))
+            .as("created")
+        }
+      yield assertTrue(
+        result == "created",
+        operations.transactionCount == 1,
+        operations.created == List((path, data)),
+      )
+    },
+    test("transaction returns application errors from the callback") {
+      val operations = RecordingGoogleFirestoreOperations()
+      val client = GoogleFirestoreDocumentClient(operations)
+
+      assertZIO(client.transaction(_ => ZIO.fail(EventStoreError.VersionConflict)).exit)(
+        Assertion.fails(Assertion.equalTo(EventStoreError.VersionConflict))
+      )
+    },
+    test("transaction maps Firestore failures to StoreUnavailable") {
+      val operations = RecordingGoogleFirestoreOperations(
+        transactionFailure =
+          Some(Status.UNAVAILABLE.withDescription("firestore down").asRuntimeException())
+      )
+      val client = GoogleFirestoreDocumentClient(operations)
+
+      assertZIO(client.transaction(_ => ZIO.succeed("unused")).exit)(
+        Assertion.fails(
+          Assertion.equalTo(EventStoreError.Unavailable("UNAVAILABLE: firestore down"))
+        )
+      )
+    },
+    test("transaction maps unexpected ALREADY_EXISTS failures to StoreUnavailable") {
+      val operations = RecordingGoogleFirestoreOperations(
+        transactionFailure =
+          Some(Status.ALREADY_EXISTS.withDescription("exists").asRuntimeException())
+      )
+      val client = GoogleFirestoreDocumentClient(operations)
+
+      assertZIO(client.transaction(_ => ZIO.succeed("unused")).exit)(
+        Assertion.fails(
+          Assertion.equalTo(EventStoreError.Unavailable("unexpected Firestore document conflict"))
+        )
+      )
+    },
+    test("transaction create maps ALREADY_EXISTS to AlreadyExists") {
+      val operations = RecordingGoogleFirestoreOperations(
+        createFailure = Some(Status.ALREADY_EXISTS.withDescription("exists").asRuntimeException())
+      )
+      val client = GoogleFirestoreDocumentClient(operations)
+
+      assertZIO(
+        client
+          .transaction(
+            _.create(path, data).mapError(toEventStoreError(EventStoreError.SlugAlreadyReserved))
+          )
+          .exit
+      )(
+        Assertion.fails(Assertion.equalTo(EventStoreError.SlugAlreadyReserved))
+      )
+    },
+    test("listDocuments delegates and returns Firestore documents") {
+      val documents = Chunk(FirestoreDocument("1", data))
+      val operations = RecordingGoogleFirestoreOperations(listResult = documents)
+      val client = GoogleFirestoreDocumentClient(operations)
+
+      for result <- client.listDocuments(FirestoreDocumentPath("articles", "id", "events"))
+      yield assertTrue(
+        result == documents,
+        operations.listed == List(FirestoreDocumentPath("articles", "id", "events")),
+      )
+    },
+    test("listDocuments maps Firestore failures") {
+      val operations = RecordingGoogleFirestoreOperations(
+        listFailure =
+          Some(Status.UNAVAILABLE.withDescription("firestore down").asRuntimeException())
+      )
+      val client = GoogleFirestoreDocumentClient(operations)
+
+      assertZIO(client.listDocuments(FirestoreDocumentPath("articles", "id", "events")).exit)(
+        Assertion.fails(
+          Assertion.equalTo(FirestoreClientError.Unavailable("UNAVAILABLE: firestore down"))
+        )
+      )
+    },
+  )
+
+  private def toEventStoreError(
+    alreadyExistsError: EventStoreError
+  )(error: FirestoreClientError): EventStoreError =
+    error match
+      case FirestoreClientError.AlreadyExists        => alreadyExistsError
+      case FirestoreClientError.Unavailable(message) => EventStoreError.Unavailable(message)
+
+private final class RecordingGoogleFirestoreOperations(
+  transactionFailure: Option[Throwable] = None,
+  val createFailure: Option[Throwable] = None,
+  listFailure: Option[Throwable] = None,
+  listResult: Chunk[FirestoreDocument] = Chunk.empty,
+) extends GoogleFirestoreOperations:
+  var transactionCount: Int = 0
+  var created: List[(FirestoreDocumentPath, Map[String, String])] = Nil
+  var listed: List[FirestoreDocumentPath] = Nil
+
+  def runTransaction[A](callback: GoogleFirestoreTransactionOperations => A): A =
+    transactionFailure.foreach(throw _)
+    transactionCount = transactionCount + 1
+    callback(RecordingGoogleFirestoreTransactionOperations(this))
+
+  def listDocuments(path: FirestoreDocumentPath): Chunk[FirestoreDocument] =
+    listFailure.foreach(throw _)
+    listed = listed :+ path
+    listResult
+
+private final class RecordingGoogleFirestoreTransactionOperations(
+  operations: RecordingGoogleFirestoreOperations
+) extends GoogleFirestoreTransactionOperations:
+
+  def create(path: FirestoreDocumentPath, data: Map[String, String]): Unit =
+    operations.createFailure.foreach(throw _)
+    operations.created = operations.created :+ (path, data)

--- a/apps/api/infrastructure/src/test/scala/morecat/infrastructure/firestore/GoogleFirestoreDocumentClientSpec.scala
+++ b/apps/api/infrastructure/src/test/scala/morecat/infrastructure/firestore/GoogleFirestoreDocumentClientSpec.scala
@@ -72,6 +72,15 @@ object GoogleFirestoreDocumentClientSpec extends ZIOSpecDefault:
         )
       )
     },
+    test("transaction preserves unexpected bridge failures as defects") {
+      val defect = RuntimeException("bridge bug")
+      val operations = RecordingGoogleFirestoreOperations(transactionFailure = Some(defect))
+      val client = GoogleFirestoreDocumentClient(operations)
+
+      assertZIO(client.transaction(_ => ZIO.succeed("unused")).exit)(
+        Assertion.dies(Assertion.equalTo(defect))
+      )
+    },
     test("transaction maps unexpected ALREADY_EXISTS failures to VersionConflict") {
       val operations = RecordingGoogleFirestoreOperations(
         transactionFailure =
@@ -156,6 +165,22 @@ object GoogleFirestoreDocumentClientSpec extends ZIOSpecDefault:
           .exit
       )(
         Assertion.fails(Assertion.equalTo(EventStoreError.SlugAlreadyReserved))
+      )
+    },
+    test("transaction create preserves unexpected bridge failures as defects") {
+      val defect = RuntimeException("bridge bug")
+      val operations = RecordingGoogleFirestoreOperations(createFailure = Some(defect))
+      val client = GoogleFirestoreDocumentClient(operations)
+
+      assertZIO(
+        client
+          .transaction(
+            _.create(path, data)
+              .mapError(FirestoreEventStoreErrorMapper.create(EventStoreError.VersionConflict))
+          )
+          .exit
+      )(
+        Assertion.dies(Assertion.equalTo(defect))
       )
     },
     test("transaction lets Firestore retry an ABORTED create") {
@@ -248,6 +273,15 @@ object GoogleFirestoreDocumentClientSpec extends ZIOSpecDefault:
         Assertion.fails(
           Assertion.equalTo(FirestoreClientError.Unavailable("UNAVAILABLE: firestore down"))
         )
+      )
+    },
+    test("listDocuments preserves unexpected bridge failures as defects") {
+      val defect = RuntimeException("bridge bug")
+      val operations = RecordingGoogleFirestoreOperations(listFailure = Some(defect))
+      val client = GoogleFirestoreDocumentClient(operations)
+
+      assertZIO(client.listDocuments(FirestoreDocumentPath("articles")).exit)(
+        Assertion.dies(Assertion.equalTo(defect))
       )
     },
   )

--- a/apps/api/infrastructure/src/test/scala/morecat/infrastructure/firestore/GoogleFirestoreDocumentClientSpec.scala
+++ b/apps/api/infrastructure/src/test/scala/morecat/infrastructure/firestore/GoogleFirestoreDocumentClientSpec.scala
@@ -171,6 +171,56 @@ object GoogleFirestoreDocumentClientSpec extends ZIOSpecDefault:
         operations.listed == List(FirestoreDocumentPath("articles", "id", "events")),
       )
     },
+    test("document decoder preserves string fields") {
+      val result = GoogleFirestoreDocumentDecoder.decode(
+        "1",
+        Map("json" -> "payload"),
+      )
+
+      assertTrue(result == FirestoreDocument("1", Map("json" -> "payload")))
+    },
+    test("document decoder rejects non-string fields with type context") {
+      assertZIO(
+        ZIO
+          .attempt(
+            GoogleFirestoreDocumentDecoder.decode(
+              "1",
+              Map("seq" -> Long.box(1L)),
+            )
+          )
+          .mapError(GoogleFirestoreErrorMapper.toClientError)
+          .exit
+      )(
+        Assertion.fails(
+          Assertion.equalTo(
+            FirestoreClientError.InvalidArgument(
+              "INVALID_ARGUMENT: Firestore document 1 field seq must be a string, found java.lang.Long"
+            )
+          )
+        )
+      )
+    },
+    test("document decoder reports null fields without exposing values") {
+      assertZIO(
+        ZIO
+          .attempt(
+            GoogleFirestoreDocumentDecoder.decode(
+              "1",
+              Map("json" -> null),
+            )
+          )
+          .mapError(GoogleFirestoreErrorMapper.toClientError)
+          .exit
+      )(
+        Assertion.fails(
+          Assertion.equalTo(
+            FirestoreClientError.InvalidArgument(
+              "INVALID_ARGUMENT: Firestore document 1 field json must be a string, found null"
+            )
+          )
+        )
+      )
+    },
     test("listDocuments maps Firestore failures") {
       val operations = RecordingGoogleFirestoreOperations(
         listFailure =

--- a/apps/api/infrastructure/src/test/scala/morecat/infrastructure/firestore/GoogleFirestoreDocumentClientSpec.scala
+++ b/apps/api/infrastructure/src/test/scala/morecat/infrastructure/firestore/GoogleFirestoreDocumentClientSpec.scala
@@ -94,6 +94,22 @@ object GoogleFirestoreDocumentClientSpec extends ZIOSpecDefault:
         Assertion.fails(Assertion.equalTo(EventStoreError.VersionConflict))
       )
     },
+    test("transaction preserves non-retryable failed preconditions") {
+      val operations = RecordingGoogleFirestoreOperations(
+        transactionFailure = Some(
+          Status.FAILED_PRECONDITION.withDescription("precondition failed").asRuntimeException()
+        )
+      )
+      val client = GoogleFirestoreDocumentClient(operations)
+
+      assertZIO(client.transaction(_ => ZIO.succeed("unused")).exit)(
+        Assertion.fails(
+          Assertion.equalTo(
+            EventStoreError.FailedPrecondition("FAILED_PRECONDITION: precondition failed")
+          )
+        )
+      )
+    },
     test("transaction preserves non-retryable permission failures") {
       val operations = RecordingGoogleFirestoreOperations(
         transactionFailure =

--- a/apps/api/infrastructure/src/test/scala/morecat/infrastructure/firestore/GoogleFirestoreDocumentClientSpec.scala
+++ b/apps/api/infrastructure/src/test/scala/morecat/infrastructure/firestore/GoogleFirestoreDocumentClientSpec.scala
@@ -123,6 +123,22 @@ object GoogleFirestoreDocumentClientSpec extends ZIOSpecDefault:
         Assertion.fails(Assertion.equalTo(EventStoreError.SlugAlreadyReserved))
       )
     },
+    test("transaction lets Firestore retry an ABORTED create") {
+      val operations = RecordingGoogleFirestoreOperations(retryAbortedCreateOnce = true)
+      val client = GoogleFirestoreDocumentClient(operations)
+
+      for result <- client.transaction { tx =>
+          tx.create(path, data)
+            .mapError(toEventStoreError(EventStoreError.SlugAlreadyReserved))
+            .as("created")
+        }
+      yield assertTrue(
+        result == "created",
+        operations.callbackCount == 2,
+        operations.createAttemptCount == 2,
+        operations.committedCount == 1,
+      )
+    },
     test("listDocuments delegates and returns Firestore documents") {
       val documents = Chunk(FirestoreDocument("1", data))
       val operations = RecordingGoogleFirestoreOperations(listResult = documents)
@@ -169,8 +185,11 @@ private final class RecordingGoogleFirestoreOperations(
   val createFailure: Option[Throwable] = None,
   listFailure: Option[Throwable] = None,
   listResult: Chunk[FirestoreDocument] = Chunk.empty,
+  val retryAbortedCreateOnce: Boolean = false,
 ) extends GoogleFirestoreOperations:
   var transactionCount: Int = 0
+  var callbackCount: Int = 0
+  var createAttemptCount: Int = 0
   var committedCount: Int = 0
   var created: List[(FirestoreDocumentPath, Map[String, String])] = Nil
   var listed: List[FirestoreDocumentPath] = Nil
@@ -178,7 +197,13 @@ private final class RecordingGoogleFirestoreOperations(
   def runTransaction[A](callback: GoogleFirestoreTransactionOperations => A): A =
     transactionFailure.foreach(throw _)
     transactionCount = transactionCount + 1
-    callback(RecordingGoogleFirestoreTransactionOperations(this))
+    callbackCount = callbackCount + 1
+    try callback(RecordingGoogleFirestoreTransactionOperations(this))
+    catch
+      case error: io.grpc.StatusRuntimeException
+          if retryAbortedCreateOnce && error.getStatus.getCode == Status.Code.ABORTED =>
+        callbackCount = callbackCount + 1
+        callback(RecordingGoogleFirestoreTransactionOperations(this))
 
   def listDocuments(path: FirestoreDocumentPath): Chunk[FirestoreDocument] =
     listFailure.foreach(throw _)
@@ -190,6 +215,9 @@ private final class RecordingGoogleFirestoreTransactionOperations(
 ) extends GoogleFirestoreTransactionOperations:
 
   def create(path: FirestoreDocumentPath, data: Map[String, String]): Unit =
+    operations.createAttemptCount = operations.createAttemptCount + 1
+    if operations.retryAbortedCreateOnce && operations.createAttemptCount == 1 then
+      throw Status.ABORTED.withDescription("transaction contention").asRuntimeException()
     operations.createFailure.foreach(throw _)
     operations.created = operations.created :+ (path, data)
 

--- a/apps/api/infrastructure/src/test/scala/morecat/infrastructure/firestore/GoogleFirestoreDocumentClientSpec.scala
+++ b/apps/api/infrastructure/src/test/scala/morecat/infrastructure/firestore/GoogleFirestoreDocumentClientSpec.scala
@@ -75,7 +75,7 @@ object GoogleFirestoreDocumentClientSpec extends ZIOSpecDefault:
         Assertion.fails(Assertion.equalTo(EventStoreError.VersionConflict))
       )
     },
-    test("transaction maps permission failures with an observable message") {
+    test("transaction preserves non-retryable permission failures") {
       val operations = RecordingGoogleFirestoreOperations(
         transactionFailure =
           Some(Status.PERMISSION_DENIED.withDescription("iam denied").asRuntimeException())
@@ -85,14 +85,12 @@ object GoogleFirestoreDocumentClientSpec extends ZIOSpecDefault:
       assertZIO(client.transaction(_ => ZIO.succeed("unused")).exit)(
         Assertion.fails(
           Assertion.equalTo(
-            EventStoreError.Unavailable(
-              "firestore permission denied: PERMISSION_DENIED: iam denied"
-            )
+            EventStoreError.PermissionDenied("PERMISSION_DENIED: iam denied")
           )
         )
       )
     },
-    test("transaction maps invalid request failures with an observable message") {
+    test("transaction preserves non-retryable invalid arguments") {
       val operations = RecordingGoogleFirestoreOperations(
         transactionFailure =
           Some(Status.INVALID_ARGUMENT.withDescription("bad request").asRuntimeException())
@@ -102,7 +100,7 @@ object GoogleFirestoreDocumentClientSpec extends ZIOSpecDefault:
       assertZIO(client.transaction(_ => ZIO.succeed("unused")).exit)(
         Assertion.fails(
           Assertion.equalTo(
-            EventStoreError.Unavailable("invalid Firestore request: INVALID_ARGUMENT: bad request")
+            EventStoreError.InvalidArgument("INVALID_ARGUMENT: bad request")
           )
         )
       )
@@ -174,9 +172,9 @@ object GoogleFirestoreDocumentClientSpec extends ZIOSpecDefault:
       case FirestoreClientError.Conflict(_) =>
         alreadyExistsError
       case FirestoreClientError.PermissionDenied(message) =>
-        EventStoreError.Unavailable(s"firestore permission denied: $message")
+        EventStoreError.PermissionDenied(message)
       case FirestoreClientError.InvalidArgument(message) =>
-        EventStoreError.Unavailable(s"invalid Firestore request: $message")
+        EventStoreError.InvalidArgument(message)
       case FirestoreClientError.Unavailable(message) =>
         EventStoreError.Unavailable(message)
 

--- a/apps/api/infrastructure/src/test/scala/morecat/infrastructure/firestore/GoogleFirestoreDocumentClientSpec.scala
+++ b/apps/api/infrastructure/src/test/scala/morecat/infrastructure/firestore/GoogleFirestoreDocumentClientSpec.scala
@@ -53,7 +53,7 @@ object GoogleFirestoreDocumentClientSpec extends ZIOSpecDefault:
         )
       )
     },
-    test("transaction maps unexpected ALREADY_EXISTS failures to StoreUnavailable") {
+    test("transaction maps unexpected ALREADY_EXISTS failures to VersionConflict") {
       val operations = RecordingGoogleFirestoreOperations(
         transactionFailure =
           Some(Status.ALREADY_EXISTS.withDescription("exists").asRuntimeException())
@@ -61,8 +61,38 @@ object GoogleFirestoreDocumentClientSpec extends ZIOSpecDefault:
       val client = GoogleFirestoreDocumentClient(operations)
 
       assertZIO(client.transaction(_ => ZIO.succeed("unused")).exit)(
+        Assertion.fails(Assertion.equalTo(EventStoreError.VersionConflict))
+      )
+    },
+    test("transaction maps permission failures with an observable message") {
+      val operations = RecordingGoogleFirestoreOperations(
+        transactionFailure =
+          Some(Status.PERMISSION_DENIED.withDescription("iam denied").asRuntimeException())
+      )
+      val client = GoogleFirestoreDocumentClient(operations)
+
+      assertZIO(client.transaction(_ => ZIO.succeed("unused")).exit)(
         Assertion.fails(
-          Assertion.equalTo(EventStoreError.Unavailable("unexpected Firestore document conflict"))
+          Assertion.equalTo(
+            EventStoreError.Unavailable(
+              "firestore permission denied: PERMISSION_DENIED: iam denied"
+            )
+          )
+        )
+      )
+    },
+    test("transaction maps invalid request failures with an observable message") {
+      val operations = RecordingGoogleFirestoreOperations(
+        transactionFailure =
+          Some(Status.INVALID_ARGUMENT.withDescription("bad request").asRuntimeException())
+      )
+      val client = GoogleFirestoreDocumentClient(operations)
+
+      assertZIO(client.transaction(_ => ZIO.succeed("unused")).exit)(
+        Assertion.fails(
+          Assertion.equalTo(
+            EventStoreError.Unavailable("invalid Firestore request: INVALID_ARGUMENT: bad request")
+          )
         )
       )
     },
@@ -112,8 +142,14 @@ object GoogleFirestoreDocumentClientSpec extends ZIOSpecDefault:
     alreadyExistsError: EventStoreError
   )(error: FirestoreClientError): EventStoreError =
     error match
-      case FirestoreClientError.AlreadyExists        => alreadyExistsError
-      case FirestoreClientError.Unavailable(message) => EventStoreError.Unavailable(message)
+      case FirestoreClientError.AlreadyExists =>
+        alreadyExistsError
+      case FirestoreClientError.PermissionDenied(message) =>
+        EventStoreError.Unavailable(s"firestore permission denied: $message")
+      case FirestoreClientError.InvalidArgument(message) =>
+        EventStoreError.Unavailable(s"invalid Firestore request: $message")
+      case FirestoreClientError.Unavailable(message) =>
+        EventStoreError.Unavailable(message)
 
 private final class RecordingGoogleFirestoreOperations(
   transactionFailure: Option[Throwable] = None,

--- a/apps/api/infrastructure/src/test/scala/morecat/infrastructure/firestore/GoogleFirestoreDocumentClientSpec.scala
+++ b/apps/api/infrastructure/src/test/scala/morecat/infrastructure/firestore/GoogleFirestoreDocumentClientSpec.scala
@@ -40,6 +40,25 @@ object GoogleFirestoreDocumentClientSpec extends ZIOSpecDefault:
         operations.committedCount == 0,
       )
     },
+    test("transaction callback inherits the current FiberRef values") {
+      val operations = RecordingGoogleFirestoreOperations()
+      val client = GoogleFirestoreDocumentClient(operations)
+
+      for
+        fiberRef <- FiberRef.make("default")
+        _ <- fiberRef.set("request-context")
+        result <- client.transaction(_ => fiberRef.get)
+      yield assertTrue(result == "request-context")
+    },
+    test("transaction preserves callback defects") {
+      val operations = RecordingGoogleFirestoreOperations()
+      val client = GoogleFirestoreDocumentClient(operations)
+      val defect = RuntimeException("callback bug")
+
+      assertZIO(client.transaction(_ => ZIO.die(defect)).exit)(
+        Assertion.dies(Assertion.equalTo(defect))
+      )
+    },
     test("transaction maps Firestore failures to StoreUnavailable") {
       val operations = RecordingGoogleFirestoreOperations(
         transactionFailure =

--- a/apps/api/infrastructure/src/test/scala/morecat/infrastructure/firestore/GoogleFirestoreDocumentClientSpec.scala
+++ b/apps/api/infrastructure/src/test/scala/morecat/infrastructure/firestore/GoogleFirestoreDocumentClientSpec.scala
@@ -27,14 +27,17 @@ object GoogleFirestoreDocumentClientSpec extends ZIOSpecDefault:
         result == "created",
         operations.transactionCount == 1,
         operations.created == List((path, data)),
+        operations.committedCount == 1,
       )
     },
     test("transaction returns application errors from the callback") {
       val operations = RecordingGoogleFirestoreOperations()
       val client = GoogleFirestoreDocumentClient(operations)
 
-      assertZIO(client.transaction(_ => ZIO.fail(EventStoreError.VersionConflict)).exit)(
-        Assertion.fails(Assertion.equalTo(EventStoreError.VersionConflict))
+      for exit <- client.transaction(_ => ZIO.fail(EventStoreError.VersionConflict)).exit
+      yield assertTrue(
+        exit == Exit.fail(EventStoreError.VersionConflict),
+        operations.committedCount == 0,
       )
     },
     test("transaction maps Firestore failures to StoreUnavailable") {
@@ -119,6 +122,7 @@ private final class RecordingGoogleFirestoreOperations(
   listResult: Chunk[FirestoreDocument] = Chunk.empty,
 ) extends GoogleFirestoreOperations:
   var transactionCount: Int = 0
+  var committedCount: Int = 0
   var created: List[(FirestoreDocumentPath, Map[String, String])] = Nil
   var listed: List[FirestoreDocumentPath] = Nil
 
@@ -139,3 +143,6 @@ private final class RecordingGoogleFirestoreTransactionOperations(
   def create(path: FirestoreDocumentPath, data: Map[String, String]): Unit =
     operations.createFailure.foreach(throw _)
     operations.created = operations.created :+ (path, data)
+
+  override def commitCreates(): Unit =
+    operations.committedCount = operations.committedCount + 1

--- a/apps/api/infrastructure/src/test/scala/morecat/infrastructure/firestore/GoogleFirestoreDocumentClientSpec.scala
+++ b/apps/api/infrastructure/src/test/scala/morecat/infrastructure/firestore/GoogleFirestoreDocumentClientSpec.scala
@@ -20,7 +20,7 @@ object GoogleFirestoreDocumentClientSpec extends ZIOSpecDefault:
 
       for result <- client.transaction { tx =>
           tx.create(path, data)
-            .mapError(toEventStoreError(EventStoreError.VersionConflict))
+            .mapError(FirestoreEventStoreErrorMapper.create(EventStoreError.VersionConflict))
             .as("created")
         }
       yield assertTrue(
@@ -133,7 +133,9 @@ object GoogleFirestoreDocumentClientSpec extends ZIOSpecDefault:
       assertZIO(
         client
           .transaction(
-            _.create(path, data).mapError(toEventStoreError(EventStoreError.SlugAlreadyReserved))
+            _.create(path, data).mapError(
+              FirestoreEventStoreErrorMapper.create(EventStoreError.SlugAlreadyReserved)
+            )
           )
           .exit
       )(
@@ -146,7 +148,9 @@ object GoogleFirestoreDocumentClientSpec extends ZIOSpecDefault:
 
       for result <- client.transaction { tx =>
           tx.create(path, data)
-            .mapError(toEventStoreError(EventStoreError.SlugAlreadyReserved))
+            .mapError(
+              FirestoreEventStoreErrorMapper.create(EventStoreError.SlugAlreadyReserved)
+            )
             .as("created")
         }
       yield assertTrue(
@@ -181,21 +185,6 @@ object GoogleFirestoreDocumentClientSpec extends ZIOSpecDefault:
       )
     },
   )
-
-  private def toEventStoreError(
-    alreadyExistsError: EventStoreError
-  )(error: FirestoreClientError): EventStoreError =
-    error match
-      case FirestoreClientError.AlreadyExists =>
-        alreadyExistsError
-      case FirestoreClientError.Conflict(_) =>
-        alreadyExistsError
-      case FirestoreClientError.PermissionDenied(message) =>
-        EventStoreError.PermissionDenied(message)
-      case FirestoreClientError.InvalidArgument(message) =>
-        EventStoreError.InvalidArgument(message)
-      case FirestoreClientError.Unavailable(message) =>
-        EventStoreError.Unavailable(message)
 
 private final class RecordingGoogleFirestoreOperations(
   transactionFailure: Option[Throwable] = None,

--- a/apps/api/infrastructure/src/test/scala/morecat/infrastructure/firestore/GoogleFirestoreErrorMapperSpec.scala
+++ b/apps/api/infrastructure/src/test/scala/morecat/infrastructure/firestore/GoogleFirestoreErrorMapperSpec.scala
@@ -1,7 +1,8 @@
 package morecat.infrastructure.firestore
 
 import com.google.cloud.firestore.FirestoreException
-import io.grpc.Status
+import io.grpc.{Status, StatusRuntimeException}
+import zio.*
 import zio.test.*
 
 import java.util.concurrent.{CompletionException, ExecutionException}
@@ -105,20 +106,18 @@ object GoogleFirestoreErrorMapperSpec extends ZIOSpecDefault:
         GoogleFirestoreErrorMapper.toClientError(error) == FirestoreClientError.AlreadyExists
       )
     },
-    test("keeps wrapper messages when ExecutionException has no cause") {
+    test("preserves a cause-less ExecutionException as a defect") {
       val error = ExecutionException("wrapper only", null)
 
-      assertTrue(
-        GoogleFirestoreErrorMapper.toClientError(error) ==
-          FirestoreClientError.Unavailable("wrapper only")
+      assertZIO(ZIO.succeed(GoogleFirestoreErrorMapper.toClientError(error)).exit)(
+        Assertion.dies(Assertion.equalTo(error))
       )
     },
-    test("keeps wrapper messages when CompletionException has no cause") {
+    test("preserves a cause-less CompletionException as a defect") {
       val error = CompletionException("wrapper only", null)
 
-      assertTrue(
-        GoogleFirestoreErrorMapper.toClientError(error) ==
-          FirestoreClientError.Unavailable("wrapper only")
+      assertZIO(ZIO.succeed(GoogleFirestoreErrorMapper.toClientError(error)).exit)(
+        Assertion.dies(Assertion.equalTo(error))
       )
     },
     test("maps other failures to Unavailable with the failure message") {
@@ -129,12 +128,20 @@ object GoogleFirestoreErrorMapperSpec extends ZIOSpecDefault:
           FirestoreClientError.Unavailable("UNAVAILABLE: firestore down")
       )
     },
-    test("falls back to toString when failures have no message") {
-      val error = RuntimeException(null: String)
+    test("falls back to toString when a recognized failure has no message") {
+      val error = new StatusRuntimeException(Status.UNAVAILABLE):
+        override def getMessage: String = null
 
       assertTrue(
         GoogleFirestoreErrorMapper.toClientError(error) ==
-          FirestoreClientError.Unavailable("java.lang.RuntimeException")
+          FirestoreClientError.Unavailable(error.toString)
+      )
+    },
+    test("preserves an unexpected failure as a defect") {
+      val error = RuntimeException(null: String)
+
+      assertZIO(ZIO.succeed(GoogleFirestoreErrorMapper.toClientError(error)).exit)(
+        Assertion.dies(Assertion.equalTo(error))
       )
     },
   )

--- a/apps/api/infrastructure/src/test/scala/morecat/infrastructure/firestore/GoogleFirestoreErrorMapperSpec.scala
+++ b/apps/api/infrastructure/src/test/scala/morecat/infrastructure/firestore/GoogleFirestoreErrorMapperSpec.scala
@@ -26,6 +26,27 @@ object GoogleFirestoreErrorMapperSpec extends ZIOSpecDefault:
         GoogleFirestoreErrorMapper.toClientError(error) == FirestoreClientError.AlreadyExists
       )
     },
+    test("maps ABORTED FirestoreException failures to Conflict") {
+      val error = FirestoreException.forServerRejection(
+        Status.ABORTED,
+        "transaction contention"
+      )
+
+      assertTrue(
+        GoogleFirestoreErrorMapper.toClientError(error) ==
+          FirestoreClientError.Conflict("transaction contention")
+      )
+    },
+    test("maps FAILED_PRECONDITION gRPC failures to Conflict") {
+      val error = Status.FAILED_PRECONDITION
+        .withDescription("precondition failed")
+        .asRuntimeException()
+
+      assertTrue(
+        GoogleFirestoreErrorMapper.toClientError(error) ==
+          FirestoreClientError.Conflict("FAILED_PRECONDITION: precondition failed")
+      )
+    },
     test("maps PERMISSION_DENIED FirestoreException failures separately") {
       val error = FirestoreException.forServerRejection(
         Status.PERMISSION_DENIED,

--- a/apps/api/infrastructure/src/test/scala/morecat/infrastructure/firestore/GoogleFirestoreErrorMapperSpec.scala
+++ b/apps/api/infrastructure/src/test/scala/morecat/infrastructure/firestore/GoogleFirestoreErrorMapperSpec.scala
@@ -26,6 +26,25 @@ object GoogleFirestoreErrorMapperSpec extends ZIOSpecDefault:
         GoogleFirestoreErrorMapper.toClientError(error) == FirestoreClientError.AlreadyExists
       )
     },
+    test("maps PERMISSION_DENIED FirestoreException failures separately") {
+      val error = FirestoreException.forServerRejection(
+        Status.PERMISSION_DENIED,
+        "iam denied"
+      )
+
+      assertTrue(
+        GoogleFirestoreErrorMapper.toClientError(error) ==
+          FirestoreClientError.PermissionDenied("iam denied")
+      )
+    },
+    test("maps INVALID_ARGUMENT gRPC failures separately") {
+      val error = Status.INVALID_ARGUMENT.withDescription("bad request").asRuntimeException()
+
+      assertTrue(
+        GoogleFirestoreErrorMapper.toClientError(error) ==
+          FirestoreClientError.InvalidArgument("INVALID_ARGUMENT: bad request")
+      )
+    },
     test("unwraps ExecutionException before mapping Firestore failures") {
       val error =
         ExecutionException(

--- a/apps/api/infrastructure/src/test/scala/morecat/infrastructure/firestore/GoogleFirestoreErrorMapperSpec.scala
+++ b/apps/api/infrastructure/src/test/scala/morecat/infrastructure/firestore/GoogleFirestoreErrorMapperSpec.scala
@@ -56,14 +56,14 @@ object GoogleFirestoreErrorMapperSpec extends ZIOSpecDefault:
         GoogleFirestoreErrorMapper.abortedCause(otherError).isEmpty,
       )
     },
-    test("maps FAILED_PRECONDITION gRPC failures to Conflict") {
+    test("maps FAILED_PRECONDITION gRPC failures separately") {
       val error = Status.FAILED_PRECONDITION
         .withDescription("precondition failed")
         .asRuntimeException()
 
       assertTrue(
         GoogleFirestoreErrorMapper.toClientError(error) ==
-          FirestoreClientError.Conflict("FAILED_PRECONDITION: precondition failed")
+          FirestoreClientError.FailedPrecondition("FAILED_PRECONDITION: precondition failed")
       )
     },
     test("maps PERMISSION_DENIED FirestoreException failures separately") {

--- a/apps/api/infrastructure/src/test/scala/morecat/infrastructure/firestore/GoogleFirestoreErrorMapperSpec.scala
+++ b/apps/api/infrastructure/src/test/scala/morecat/infrastructure/firestore/GoogleFirestoreErrorMapperSpec.scala
@@ -37,6 +37,25 @@ object GoogleFirestoreErrorMapperSpec extends ZIOSpecDefault:
           FirestoreClientError.Conflict("transaction contention")
       )
     },
+    test("returns an unwrapped ABORTED Firestore cause for transaction retry") {
+      val cause = FirestoreException.forServerRejection(
+        Status.ABORTED,
+        "transaction contention"
+      )
+
+      assertTrue(
+        GoogleFirestoreErrorMapper.abortedCause(ExecutionException(cause)).contains(cause)
+      )
+    },
+    test("does not retry non-ABORTED Firestore failures") {
+      val grpcError = Status.FAILED_PRECONDITION.asRuntimeException()
+      val otherError = RuntimeException("failed")
+
+      assertTrue(
+        GoogleFirestoreErrorMapper.abortedCause(grpcError).isEmpty,
+        GoogleFirestoreErrorMapper.abortedCause(otherError).isEmpty,
+      )
+    },
     test("maps FAILED_PRECONDITION gRPC failures to Conflict") {
       val error = Status.FAILED_PRECONDITION
         .withDescription("precondition failed")

--- a/apps/api/infrastructure/src/test/scala/morecat/infrastructure/firestore/GoogleFirestoreErrorMapperSpec.scala
+++ b/apps/api/infrastructure/src/test/scala/morecat/infrastructure/firestore/GoogleFirestoreErrorMapperSpec.scala
@@ -1,0 +1,70 @@
+package morecat.infrastructure.firestore
+
+import io.grpc.Status
+import zio.test.*
+
+import java.util.concurrent.{CompletionException, ExecutionException}
+
+object GoogleFirestoreErrorMapperSpec extends ZIOSpecDefault:
+
+  def spec = suite("GoogleFirestoreErrorMapper")(
+    test("maps ALREADY_EXISTS gRPC failures to AlreadyExists") {
+      val error = Status.ALREADY_EXISTS.withDescription("document exists").asRuntimeException()
+
+      assertTrue(
+        GoogleFirestoreErrorMapper.toClientError(error) == FirestoreClientError.AlreadyExists
+      )
+    },
+    test("unwraps ExecutionException before mapping Firestore failures") {
+      val error =
+        ExecutionException(
+          Status.ALREADY_EXISTS.withDescription("document exists").asRuntimeException()
+        )
+
+      assertTrue(
+        GoogleFirestoreErrorMapper.toClientError(error) == FirestoreClientError.AlreadyExists
+      )
+    },
+    test("unwraps CompletionException before mapping Firestore failures") {
+      val error =
+        CompletionException(
+          Status.ALREADY_EXISTS.withDescription("document exists").asRuntimeException()
+        )
+
+      assertTrue(
+        GoogleFirestoreErrorMapper.toClientError(error) == FirestoreClientError.AlreadyExists
+      )
+    },
+    test("keeps wrapper messages when ExecutionException has no cause") {
+      val error = ExecutionException("wrapper only", null)
+
+      assertTrue(
+        GoogleFirestoreErrorMapper.toClientError(error) ==
+          FirestoreClientError.Unavailable("wrapper only")
+      )
+    },
+    test("keeps wrapper messages when CompletionException has no cause") {
+      val error = CompletionException("wrapper only", null)
+
+      assertTrue(
+        GoogleFirestoreErrorMapper.toClientError(error) ==
+          FirestoreClientError.Unavailable("wrapper only")
+      )
+    },
+    test("maps other failures to Unavailable with the failure message") {
+      val error = Status.UNAVAILABLE.withDescription("firestore down").asRuntimeException()
+
+      assertTrue(
+        GoogleFirestoreErrorMapper.toClientError(error) ==
+          FirestoreClientError.Unavailable("UNAVAILABLE: firestore down")
+      )
+    },
+    test("falls back to toString when failures have no message") {
+      val error = RuntimeException(null: String)
+
+      assertTrue(
+        GoogleFirestoreErrorMapper.toClientError(error) ==
+          FirestoreClientError.Unavailable("java.lang.RuntimeException")
+      )
+    },
+  )

--- a/apps/api/infrastructure/src/test/scala/morecat/infrastructure/firestore/GoogleFirestoreErrorMapperSpec.scala
+++ b/apps/api/infrastructure/src/test/scala/morecat/infrastructure/firestore/GoogleFirestoreErrorMapperSpec.scala
@@ -1,5 +1,6 @@
 package morecat.infrastructure.firestore
 
+import com.google.cloud.firestore.FirestoreException
 import io.grpc.Status
 import zio.test.*
 
@@ -10,6 +11,16 @@ object GoogleFirestoreErrorMapperSpec extends ZIOSpecDefault:
   def spec = suite("GoogleFirestoreErrorMapper")(
     test("maps ALREADY_EXISTS gRPC failures to AlreadyExists") {
       val error = Status.ALREADY_EXISTS.withDescription("document exists").asRuntimeException()
+
+      assertTrue(
+        GoogleFirestoreErrorMapper.toClientError(error) == FirestoreClientError.AlreadyExists
+      )
+    },
+    test("maps ALREADY_EXISTS FirestoreException failures to AlreadyExists") {
+      val error = FirestoreException.forServerRejection(
+        Status.ALREADY_EXISTS,
+        "document exists"
+      )
 
       assertTrue(
         GoogleFirestoreErrorMapper.toClientError(error) == FirestoreClientError.AlreadyExists

--- a/flake.nix
+++ b/flake.nix
@@ -15,7 +15,7 @@
         jdk = pkgs.jdk25;
         sbt = pkgs.sbt.override { jre = jdk; };
 
-        scalaPkgs = [ jdk sbt pkgs.coursier ]; # apps/api
+        scalaPkgs = [ jdk sbt pkgs.coursier pkgs.firebase-tools ]; # apps/api
         rustPkgs = [ pkgs.cargo pkgs.rustc pkgs.rustfmt pkgs.clippy ]; # apps/rmu
         nodePkgs = [ pkgs.nodejs_22 ]; # apps/ui
 


### PR DESCRIPTION
## Summary

- Add the Google Cloud Firestore JVM SDK dependency to the API infrastructure project.
- Add `GoogleFirestoreDocumentClient` as the Firestore SDK-backed implementation of the existing document client port.
- Add Firestore/gRPC error mapping, including wrapped `ExecutionException` and `CompletionException` failures from SDK futures.
- Cover transaction delegation, create conflict mapping, list delegation, and error mapping behavior with zio-test specs.

## Validation

```sh
nix develop .#scala --command bash -c 'cd apps/api && sbt -batch -no-colors scalafmtCheckAll clean coverage domain/test application/test infrastructure/test coverageAggregate'
```

Result: passed with statement coverage 100.00% and branch coverage 100.00%.