### PR TITLE
feat(api): add bearer authentication boundary

### DIFF
--- a/apps/api/application/src/main/scala/morecat/application/Authentication.scala
+++ b/apps/api/application/src/main/scala/morecat/application/Authentication.scala
@@ -1,0 +1,9 @@
+package morecat.application
+
+import zio.*
+
+enum AuthenticationError:
+  case InvalidCredentials
+
+trait Authenticator:
+  def authenticate(bearerToken: String): IO[AuthenticationError, Unit]

--- a/apps/api/build.sbt
+++ b/apps/api/build.sbt
@@ -5,6 +5,7 @@ val scala3      = "3.8.4"
 val zioVersion  = "2.1.26"
 val ironVersion = "3.3.1"
 val zioJsonVersion = "0.9.0"
+val tapirVersion = "1.13.27"
 val googleCloudFirestoreVersion = "3.43.1"
 
 lazy val FirestoreIntegration = config("firestoreIntegration") extend Test
@@ -71,6 +72,7 @@ lazy val infrastructure = project
     libraryDependencies ++= Seq(
       "dev.zio" %% "zio"          % zioVersion,
       "dev.zio" %% "zio-json"     % zioJsonVersion,
+      "com.softwaremill.sttp.tapir" %% "tapir-zio-http-server" % tapirVersion,
       "com.google.cloud" % "google-cloud-firestore" % googleCloudFirestoreVersion,
       "dev.zio" %% "zio-test"     % zioVersion % Test,
       "dev.zio" %% "zio-test-sbt" % zioVersion % Test,

--- a/apps/api/infrastructure/src/main/scala/morecat/infrastructure/auth/BearerTokenAuthenticator.scala
+++ b/apps/api/infrastructure/src/main/scala/morecat/infrastructure/auth/BearerTokenAuthenticator.scala
@@ -1,0 +1,23 @@
+package morecat.infrastructure.auth
+
+import morecat.application.{AuthenticationError, Authenticator}
+import zio.*
+
+import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
+
+final class BearerTokenAuthenticator private (expectedToken: Array[Byte]) extends Authenticator:
+  override def authenticate(bearerToken: String): IO[AuthenticationError, Unit] =
+    ZIO.cond(
+      MessageDigest.isEqual(expectedToken, bearerToken.getBytes(StandardCharsets.UTF_8)),
+      (),
+      AuthenticationError.InvalidCredentials,
+    )
+
+object BearerTokenAuthenticator:
+  enum ConfigurationError:
+    case EmptyExpectedToken
+
+  def make(expectedToken: String): Either[ConfigurationError, BearerTokenAuthenticator] =
+    if expectedToken.isEmpty then Left(ConfigurationError.EmptyExpectedToken)
+    else Right(BearerTokenAuthenticator(expectedToken.getBytes(StandardCharsets.UTF_8)))

--- a/apps/api/infrastructure/src/main/scala/morecat/infrastructure/http/CommandSecurity.scala
+++ b/apps/api/infrastructure/src/main/scala/morecat/infrastructure/http/CommandSecurity.scala
@@ -1,0 +1,20 @@
+package morecat.infrastructure.http
+
+import morecat.application.Authenticator
+import sttp.model.StatusCode
+import sttp.tapir.ztapir.*
+import zio.*
+
+final class CommandSecurity(authenticator: Authenticator):
+  val endpoint = sttp.tapir.ztapir.endpoint
+    .securityIn(auth.bearer[String]())
+    .errorOut(statusCode)
+    .zServerSecurityLogic[Any, Unit](bearerToken =>
+      authenticate(bearerToken).flatMap(ZIO.fromEither)
+    )
+
+  def authenticate(bearerToken: String): UIO[Either[StatusCode, Unit]] =
+    authenticator
+      .authenticate(bearerToken)
+      .as(Right(()))
+      .catchAll(_ => ZIO.succeed(Left(StatusCode.Unauthorized)))

--- a/apps/api/infrastructure/src/test/scala/morecat/infrastructure/auth/BearerTokenAuthenticatorSpec.scala
+++ b/apps/api/infrastructure/src/test/scala/morecat/infrastructure/auth/BearerTokenAuthenticatorSpec.scala
@@ -1,0 +1,32 @@
+package morecat.infrastructure.auth
+
+import zio.*
+import zio.test.*
+
+object BearerTokenAuthenticatorSpec extends ZIOSpecDefault:
+
+  def spec = suite("BearerTokenAuthenticator")(
+    test("accepts the configured bearer token") {
+      val authenticator = BearerTokenAuthenticator.make("expected-token").toOption.get
+
+      assertZIO(authenticator.authenticate("expected-token").exit)(
+        Assertion.succeeds(Assertion.anything)
+      )
+    },
+    test("rejects a different bearer token without exposing it") {
+      val authenticator = BearerTokenAuthenticator.make("expected-token").toOption.get
+
+      assertZIO(authenticator.authenticate("presented-secret").exit)(
+        Assertion.fails(
+          Assertion.equalTo(morecat.application.AuthenticationError.InvalidCredentials)
+        )
+      )
+    },
+    test("rejects an empty configured token") {
+      assertTrue(
+        BearerTokenAuthenticator.make("") == Left(
+          BearerTokenAuthenticator.ConfigurationError.EmptyExpectedToken
+        )
+      )
+    }
+  )

--- a/apps/api/infrastructure/src/test/scala/morecat/infrastructure/http/CommandSecuritySpec.scala
+++ b/apps/api/infrastructure/src/test/scala/morecat/infrastructure/http/CommandSecuritySpec.scala
@@ -1,0 +1,46 @@
+package morecat.infrastructure.http
+
+import morecat.infrastructure.auth.BearerTokenAuthenticator
+import sttp.model.StatusCode
+import sttp.tapir.server.ziohttp.ZioHttpInterpreter
+import sttp.tapir.ztapir.*
+import zio.*
+import zio.http.{Request, Response, Routes, Status, URL}
+import zio.test.*
+
+object CommandSecuritySpec extends ZIOSpecDefault:
+
+  private val authenticator =
+    BearerTokenAuthenticator.make("expected-token").toOption.get
+
+  def spec = suite("CommandSecurity")(
+    test("accepts the configured bearer token") {
+      val security = CommandSecurity(authenticator)
+
+      assertZIO(security.authenticate("expected-token"))(
+        Assertion.isRight(Assertion.isUnit)
+      )
+    },
+    test("rejects an invalid bearer token as unauthorized") {
+      val security = CommandSecurity(authenticator)
+
+      assertZIO(security.authenticate("presented-secret"))(
+        Assertion.isLeft(Assertion.equalTo(StatusCode.Unauthorized))
+      )
+    },
+    test("rejects a missing authorization header as unauthorized") {
+      val security = CommandSecurity(authenticator)
+      val logic: Unit => Unit => UIO[StatusCode] =
+        _ => _ => ZIO.succeed(StatusCode.NoContent)
+      val probe = security.endpoint.get
+        .in("probe")
+        .out(statusCode)
+        .serverLogic[Any](logic)
+      val routes: Routes[Any, Response] = ZioHttpInterpreter().toHttp(probe)
+      val request = Request.get(URL.decode("http://localhost/probe").toOption.get)
+
+      assertZIO(routes.runZIO(request).map(_.status))(
+        Assertion.equalTo(Status.Unauthorized)
+      )
+    },
+  )

--- a/apps/api/infrastructure/src/test/scala/morecat/infrastructure/http/CommandSecuritySpec.scala
+++ b/apps/api/infrastructure/src/test/scala/morecat/infrastructure/http/CommandSecuritySpec.scala
@@ -5,7 +5,7 @@ import sttp.model.StatusCode
 import sttp.tapir.server.ziohttp.ZioHttpInterpreter
 import sttp.tapir.ztapir.*
 import zio.*
-import zio.http.{Request, Response, Routes, Status, URL}
+import zio.http.{Header, Request, Response, Routes, Status, URL}
 import zio.test.*
 
 object CommandSecuritySpec extends ZIOSpecDefault:
@@ -38,6 +38,23 @@ object CommandSecuritySpec extends ZIOSpecDefault:
         .serverLogic[Any](logic)
       val routes: Routes[Any, Response] = ZioHttpInterpreter().toHttp(probe)
       val request = Request.get(URL.decode("http://localhost/probe").toOption.get)
+
+      assertZIO(routes.runZIO(request).map(_.status))(
+        Assertion.equalTo(Status.Unauthorized)
+      )
+    },
+    test("rejects an invalid bearer token through the HTTP route") {
+      val security = CommandSecurity(authenticator)
+      val logic: Unit => Unit => UIO[StatusCode] =
+        _ => _ => ZIO.succeed(StatusCode.NoContent)
+      val probe = security.endpoint.get
+        .in("probe")
+        .out(statusCode)
+        .serverLogic[Any](logic)
+      val routes: Routes[Any, Response] = ZioHttpInterpreter().toHttp(probe)
+      val request = Request
+        .get(URL.decode("http://localhost/probe").toOption.get)
+        .addHeader(Header.Authorization.Bearer("presented-secret"))
 
       assertZIO(routes.runZIO(request).map(_.status))(
         Assertion.equalTo(Status.Unauthorized)


### PR DESCRIPTION
## 概要

- application 層に `Authenticator` port と認証エラーを追加
- 固定 Bearer token を定数時間比較する infrastructure 実装を追加
- Tapir 1.13.27 / zio-http を導入し、command endpoint 用の再利用可能な security base endpoint を追加
- トークン欠落・不正時に `401 Unauthorized` を返し、トークンや認証詳細をエラーへ露出しないことをテスト

## 目的

`docs/slice-1-plan.md` のタスク2で定義された認証境界を先行して用意します。今後の `POST /articles` と publish endpoint は `CommandSecurity.endpoint` を継承して認証必須にできます。公開 GET endpoint はこの境界を使用しません。

## 検証

```sh
firebase emulators:exec --only firestore --project demo-morecat 'sbt -batch -no-colors coverage domain/test application/test infrastructure/test "infrastructure / FirestoreIntegration / test" coverageAggregate'
```

- unit tests: 85 passed
- Firestore integration tests: 6 passed
- statement coverage: 100.00%
- branch coverage: 100.00%

## レビュー用セットアップ

リポジトリルートで `nix develop` に入り、`apps/api` を sbt build root として上記コマンドを実行してください。Firestore Emulator が必要です。