### PR TITLE
feat(api): generate UUIDv7 article IDs

### DIFF
--- a/apps/api/application/src/main/scala/morecat/application/ArticlePorts.scala
+++ b/apps/api/application/src/main/scala/morecat/application/ArticlePorts.scala
@@ -23,6 +23,9 @@ trait ArticleEventStore:
 trait ServerClock:
   def nowMillis: UIO[Long]
 
+trait ArticleIdGenerator:
+  def next: UIO[ArticleId]
+
 final case class PublishedArticle(
   id: ArticleId,
   slug: Slug,

--- a/apps/api/build.sbt
+++ b/apps/api/build.sbt
@@ -6,6 +6,7 @@ val zioVersion  = "2.1.26"
 val ironVersion = "3.3.1"
 val zioJsonVersion = "0.9.0"
 val tapirVersion = "1.13.27"
+val javaUuidGeneratorVersion = "5.2.0"
 val googleCloudFirestoreVersion = "3.43.1"
 
 lazy val FirestoreIntegration = config("firestoreIntegration") extend Test
@@ -73,6 +74,7 @@ lazy val infrastructure = project
       "dev.zio" %% "zio"          % zioVersion,
       "dev.zio" %% "zio-json"     % zioJsonVersion,
       "com.softwaremill.sttp.tapir" %% "tapir-zio-http-server" % tapirVersion,
+      "com.fasterxml.uuid" % "java-uuid-generator" % javaUuidGeneratorVersion,
       "com.google.cloud" % "google-cloud-firestore" % googleCloudFirestoreVersion,
       "dev.zio" %% "zio-test"     % zioVersion % Test,
       "dev.zio" %% "zio-test-sbt" % zioVersion % Test,

--- a/apps/api/infrastructure/src/main/scala/morecat/infrastructure/id/UuidV7ArticleIdGenerator.scala
+++ b/apps/api/infrastructure/src/main/scala/morecat/infrastructure/id/UuidV7ArticleIdGenerator.scala
@@ -1,0 +1,12 @@
+package morecat.infrastructure.id
+
+import com.fasterxml.uuid.Generators
+import morecat.application.ArticleIdGenerator
+import morecat.domain.ArticleId
+import zio.*
+
+final class UuidV7ArticleIdGenerator extends ArticleIdGenerator:
+  private val generator = Generators.timeBasedEpochGenerator()
+
+  override def next: UIO[ArticleId] =
+    ZIO.succeed(ArticleId.fromString(generator.generate().toString))

--- a/apps/api/infrastructure/src/test/scala/morecat/infrastructure/id/UuidV7ArticleIdGeneratorSpec.scala
+++ b/apps/api/infrastructure/src/test/scala/morecat/infrastructure/id/UuidV7ArticleIdGeneratorSpec.scala
@@ -1,0 +1,30 @@
+package morecat.infrastructure.id
+
+import zio.*
+import zio.test.*
+
+import java.util.UUID
+
+object UuidV7ArticleIdGeneratorSpec extends ZIOSpecDefault:
+
+  def spec = suite("UuidV7ArticleIdGenerator")(
+    test("generates an RFC 9562 version 7 UUID") {
+      val generator = UuidV7ArticleIdGenerator()
+
+      assertZIO(generator.next.map(id => UUID.fromString(id.asString).version()))(
+        Assertion.equalTo(7)
+      )
+    },
+    test("generates distinct IDs concurrently") {
+      val generator = UuidV7ArticleIdGenerator()
+
+      for ids <- ZIO.collectAllPar(List.fill(100)(generator.next))
+      yield assertTrue(ids.map(_.asString).distinct.size == 100)
+    },
+    test("preserves the canonical UUID string in ArticleId") {
+      val generator = UuidV7ArticleIdGenerator()
+
+      for id <- generator.next
+      yield assertTrue(UUID.fromString(id.asString).toString == id.asString)
+    },
+  )


### PR DESCRIPTION
## 概要

- application 層に `ArticleIdGenerator` port を追加
- infrastructure 層に RFC 9562 UUIDv7 を生成する実装を追加
- `java-uuid-generator` 5.2.0 を導入
- version 7、canonical 文字列表現、並行生成時の一意性をテスト

## 目的

`docs/slice-1-plan.md` で infrastructure の責務とされている UUIDv7 採番を実装し、次の `POST /articles` endpoint が生成済み `ArticleId` を `CreateDraftCommand` へ渡せるようにします。domain の `ArticleId` は引き続き表現非依存です。

## 検証

```sh
firebase emulators:exec --only firestore --project demo-morecat 'sbt -batch -no-colors coverage domain/test application/test infrastructure/test "infrastructure / FirestoreIntegration / test" coverageAggregate'
```

- unit tests: 88 passed
- Firestore integration tests: 6 passed
- statement coverage: 100.00%
- branch coverage: 100.00%

## レビュー用セットアップ

リポジトリルートで `nix develop` に入り、`apps/api` を sbt build root として上記コマンドを実行してください。Firestore Emulator が必要です。