### PR TITLE
feat(api): add create article endpoint

### DIFF
--- a/apps/api/build.sbt
+++ b/apps/api/build.sbt
@@ -74,6 +74,7 @@ lazy val infrastructure = project
       "dev.zio" %% "zio"          % zioVersion,
       "dev.zio" %% "zio-json"     % zioJsonVersion,
       "com.softwaremill.sttp.tapir" %% "tapir-zio-http-server" % tapirVersion,
+      "com.softwaremill.sttp.tapir" %% "tapir-json-zio" % tapirVersion,
       "com.fasterxml.uuid" % "java-uuid-generator" % javaUuidGeneratorVersion,
       "com.google.cloud" % "google-cloud-firestore" % googleCloudFirestoreVersion,
       "dev.zio" %% "zio-test"     % zioVersion % Test,

--- a/apps/api/infrastructure/src/main/scala/morecat/infrastructure/http/CreateArticleEndpoint.scala
+++ b/apps/api/infrastructure/src/main/scala/morecat/infrastructure/http/CreateArticleEndpoint.scala
@@ -18,7 +18,9 @@ object CreateArticleRequest:
   private val ExpectedFields = Set("slug", "title", "body")
 
   given JsonDecoder[CreateArticleRequest] = JsonDecoder[Json].mapOrFail {
-    case obj: Json.Obj if obj.fields.map(_._1).toSet == ExpectedFields =>
+    case obj: Json.Obj
+        if obj.fields.size == ExpectedFields.size &&
+          obj.fields.map(_._1).toSet == ExpectedFields =>
       obj.toJson
         .fromJson[Wire]
         .map(wire => CreateArticleRequest(wire.slug, wire.title, wire.body))

--- a/apps/api/infrastructure/src/main/scala/morecat/infrastructure/http/CreateArticleEndpoint.scala
+++ b/apps/api/infrastructure/src/main/scala/morecat/infrastructure/http/CreateArticleEndpoint.scala
@@ -1,0 +1,60 @@
+package morecat.infrastructure.http
+
+import morecat.application.*
+import sttp.model.StatusCode
+import sttp.tapir.Schema
+import sttp.tapir.json.zio.*
+import sttp.tapir.ztapir.*
+import zio.*
+import zio.json.*
+import zio.json.ast.Json
+
+final case class CreateArticleRequest(slug: String, title: String, body: String)
+    derives JsonEncoder,
+      Schema
+
+object CreateArticleRequest:
+  private final case class Wire(slug: String, title: String, body: String) derives JsonDecoder
+  private val ExpectedFields = Set("slug", "title", "body")
+
+  given JsonDecoder[CreateArticleRequest] = JsonDecoder[Json].mapOrFail {
+    case obj: Json.Obj if obj.fields.map(_._1).toSet == ExpectedFields =>
+      obj.toJson
+        .fromJson[Wire]
+        .map(wire => CreateArticleRequest(wire.slug, wire.title, wire.body))
+    case _: Json.Obj => Left("create article request contains unknown or missing fields")
+    case _           => Left("create article request must be a JSON object")
+  }
+
+final case class CreateArticleResponse(articleId: String) derives JsonCodec, Schema
+
+final class CreateArticleEndpoint(
+  security: CommandSecurity,
+  idGenerator: ArticleIdGenerator,
+  createDraft: CreateDraftCommand => IO[CommandError, Unit],
+):
+  val endpoint = security.endpoint.post
+    .in("articles")
+    .in(jsonBody[CreateArticleRequest])
+    .out(statusCode(StatusCode.Created))
+    .out(jsonBody[CreateArticleResponse])
+    .serverLogic[Any](_ => request => create(request).flatMap(ZIO.fromEither))
+
+  def create(request: CreateArticleRequest): UIO[Either[StatusCode, CreateArticleResponse]] =
+    (for
+      articleId <- idGenerator.next
+      _ <- createDraft(
+        CreateDraftCommand(articleId, request.slug, request.title, request.body)
+      )
+    yield CreateArticleResponse(articleId.asString))
+      .mapError(toStatusCode)
+      .either
+
+  private def toStatusCode(error: CommandError): StatusCode =
+    error match
+      case CommandError.InvalidDraft(_)  => StatusCode.BadRequest
+      case CommandError.SlugConflict     => StatusCode.Conflict
+      case CommandError.VersionConflict  => StatusCode.Conflict
+      case CommandError.ArticleNotFound  => StatusCode.NotFound
+      case CommandError.StoreFailure     => StatusCode.InternalServerError
+      case CommandError.StoreUnavailable => StatusCode.ServiceUnavailable

--- a/apps/api/infrastructure/src/test/scala/morecat/infrastructure/http/CreateArticleEndpointSpec.scala
+++ b/apps/api/infrastructure/src/test/scala/morecat/infrastructure/http/CreateArticleEndpointSpec.scala
@@ -117,6 +117,24 @@ object CreateArticleEndpointSpec extends ZIOSpecDefault:
         wasCalled <- called.get
       yield assertTrue(response.status == Status.BadRequest, !wasCalled)
     },
+    test("rejects duplicate JSON fields before creating a draft") {
+      for
+        called <- Ref.make(false)
+        endpoint = CreateArticleEndpoint(
+          security,
+          idGenerator,
+          _ => called.set(true),
+        )
+        routes: Routes[Any, Response] = ZioHttpInterpreter().toHttp(endpoint.endpoint)
+        response <- routes.runZIO(
+          request(
+            """{"slug":"first","slug":"second","title":"Hello","body":"body"}""",
+            true,
+          )
+        )
+        wasCalled <- called.get
+      yield assertTrue(response.status == Status.BadRequest, !wasCalled)
+    },
     test("rejects a non-object JSON request before creating a draft") {
       for
         called <- Ref.make(false)

--- a/apps/api/infrastructure/src/test/scala/morecat/infrastructure/http/CreateArticleEndpointSpec.scala
+++ b/apps/api/infrastructure/src/test/scala/morecat/infrastructure/http/CreateArticleEndpointSpec.scala
@@ -1,0 +1,133 @@
+package morecat.infrastructure.http
+
+import morecat.application.*
+import morecat.domain.{ArticleDrafted, ArticleId}
+import morecat.infrastructure.auth.BearerTokenAuthenticator
+import sttp.model.StatusCode
+import sttp.tapir.server.ziohttp.ZioHttpInterpreter
+import zio.*
+import zio.http.{Body, Header, MediaType, Request, Response, Routes, Status, URL}
+import zio.json.*
+import zio.test.*
+
+object CreateArticleEndpointSpec extends ZIOSpecDefault:
+
+  private val generatedId =
+    ArticleId.fromString("018f4edc-1f5a-7c4b-aef9-000000000001")
+
+  private val idGenerator = new ArticleIdGenerator:
+    override def next: UIO[ArticleId] = ZIO.succeed(generatedId)
+
+  private val security = CommandSecurity(
+    BearerTokenAuthenticator.make("expected-token").toOption.get
+  )
+
+  private def request(json: String, authenticated: Boolean): Request =
+    val base = Request
+      .post(URL.decode("http://localhost/articles").toOption.get, Body.fromString(json))
+      .addHeader(Header.ContentType(MediaType.application.json))
+    if authenticated then base.addHeader(Header.Authorization.Bearer("expected-token"))
+    else base
+
+  def spec = suite("CreateArticleEndpoint")(
+    test("creates a draft with a generated ID and returns it") {
+      for
+        recorded <- Ref.make(Option.empty[CreateDraftCommand])
+        endpoint = CreateArticleEndpoint(
+          security,
+          idGenerator,
+          command => recorded.set(Some(command)),
+        )
+        result <- endpoint.create(CreateArticleRequest("hello-world", "Hello", "body"))
+        command <- recorded.get
+      yield assertTrue(
+        result == Right(CreateArticleResponse(generatedId.asString)),
+        command.contains(
+          CreateDraftCommand(generatedId, "hello-world", "Hello", "body")
+        ),
+      )
+    },
+    test("maps command errors to HTTP statuses") {
+      val cases = List(
+        CommandError.InvalidDraft(Chunk(ArticleDrafted.ValidationError.InvalidSlug)) ->
+          StatusCode.BadRequest,
+        CommandError.SlugConflict -> StatusCode.Conflict,
+        CommandError.VersionConflict -> StatusCode.Conflict,
+        CommandError.ArticleNotFound -> StatusCode.NotFound,
+        CommandError.StoreFailure -> StatusCode.InternalServerError,
+        CommandError.StoreUnavailable -> StatusCode.ServiceUnavailable,
+      )
+
+      ZIO
+        .foreach(cases) { case (error, expectedStatus) =>
+          val endpoint = CreateArticleEndpoint(security, idGenerator, _ => ZIO.fail(error))
+
+          assertZIO(
+            endpoint.create(CreateArticleRequest("hello-world", "Hello", "body"))
+          )(Assertion.isLeft(Assertion.equalTo(expectedStatus)))
+        }
+        .map(_.reduce(_ && _))
+    },
+    test("serves the authenticated create endpoint over HTTP") {
+      val endpoint = CreateArticleEndpoint(security, idGenerator, _ => ZIO.unit)
+      val routes: Routes[Any, Response] = ZioHttpInterpreter().toHttp(endpoint.endpoint)
+
+      for
+        response <- routes.runZIO(
+          request("""{"slug":"hello-world","title":"Hello","body":"body"}""", true)
+        )
+        body <- response.body.asString
+      yield assertTrue(
+        response.status == Status.Created,
+        body.fromJson[CreateArticleResponse] == Right(
+          CreateArticleResponse(generatedId.asString)
+        ),
+      )
+    },
+    test("rejects a missing bearer token before creating a draft") {
+      for
+        called <- Ref.make(false)
+        endpoint = CreateArticleEndpoint(
+          security,
+          idGenerator,
+          _ => called.set(true),
+        )
+        routes: Routes[Any, Response] = ZioHttpInterpreter().toHttp(endpoint.endpoint)
+        response <- routes.runZIO(
+          request("""{"slug":"hello-world","title":"Hello","body":"body"}""", false)
+        )
+        wasCalled <- called.get
+      yield assertTrue(response.status == Status.Unauthorized, !wasCalled)
+    },
+    test("rejects unknown JSON fields before creating a draft") {
+      for
+        called <- Ref.make(false)
+        endpoint = CreateArticleEndpoint(
+          security,
+          idGenerator,
+          _ => called.set(true),
+        )
+        routes: Routes[Any, Response] = ZioHttpInterpreter().toHttp(endpoint.endpoint)
+        response <- routes.runZIO(
+          request(
+            """{"slug":"hello-world","title":"Hello","body":"body","admin":true}""",
+            true,
+          )
+        )
+        wasCalled <- called.get
+      yield assertTrue(response.status == Status.BadRequest, !wasCalled)
+    },
+    test("rejects a non-object JSON request before creating a draft") {
+      for
+        called <- Ref.make(false)
+        endpoint = CreateArticleEndpoint(
+          security,
+          idGenerator,
+          _ => called.set(true),
+        )
+        routes: Routes[Any, Response] = ZioHttpInterpreter().toHttp(endpoint.endpoint)
+        response <- routes.runZIO(request("[]", true))
+        wasCalled <- called.get
+      yield assertTrue(response.status == Status.BadRequest, !wasCalled)
+    },
+  )

--- a/apps/api/infrastructure/src/test/scala/morecat/infrastructure/http/CreateArticleEndpointSpec.scala
+++ b/apps/api/infrastructure/src/test/scala/morecat/infrastructure/http/CreateArticleEndpointSpec.scala
@@ -110,7 +110,7 @@ object CreateArticleEndpointSpec extends ZIOSpecDefault:
         routes: Routes[Any, Response] = ZioHttpInterpreter().toHttp(endpoint.endpoint)
         response <- routes.runZIO(
           request(
-            """{"slug":"hello-world","title":"Hello","body":"body","admin":true}""",
+            """{"slug":"hello-world","title":"Hello","admin":true}""",
             true,
           )
         )


### PR DESCRIPTION
## 概要

- 認証必須の `POST /articles` Tapir endpoint を追加
- `ArticleIdGenerator` で UUIDv7 を採番し、`CreateDraftCommand` と成功レスポンスへ同じ ID を渡す
- 成功時は `201 Created` と article ID の JSON を返す
- command error を `400 / 404 / 409 / 500 / 503` に分類
- 未知フィールドや JSON object 以外の request を decode 境界で `400` にする
- Tapir の zio-json integration を追加

## 目的

`docs/slice-1-plan.md` のタスク2にある draft 作成 API を HTTP 境界へ接続します。前 PR で追加した Bearer security base endpoint と UUIDv7 generator を利用し、認証・採番・入力 decode・application command 呼び出しを一つの endpoint として成立させます。

## 検証

```sh
firebase emulators:exec --only firestore --project demo-morecat 'sbt -batch -no-colors coverage domain/test application/test infrastructure/test "infrastructure / FirestoreIntegration / test" coverageAggregate'
```

- unit tests: 94 passed
- Firestore integration tests: 6 passed
- statement coverage: 100.00%
- branch coverage: 100.00%

## レビュー用セットアップ

リポジトリルートで `nix develop` に入り、`apps/api` を sbt build root として上記コマンドを実行してください。Firestore Emulator が必要です。