### PR TITLE
feat(api): add the HTTP server bootstrap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Unit, Firestore integration & coverage (apps/api)
         run: |
-          nix develop .#scala --command bash -c 'cd apps/api && firebase emulators:exec --only firestore --project demo-morecat "sbt -batch -no-colors coverage domain/test application/test infrastructure/test \"infrastructure / FirestoreIntegration / test\" coverageAggregate"'
+          nix develop .#scala --command bash -c 'cd apps/api && firebase emulators:exec --only firestore --project demo-morecat "sbt -batch -no-colors coverage domain/test application/test infrastructure/test bootstrap/test \"infrastructure / FirestoreIntegration / test\" coverageAggregate"'
 
       - name: Upload coverage report
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@
 
 ## Build, Test, and Development Commands
 - 開発環境: ルートで `nix develop`（flake で JDK 25 / sbt / Node / Rust を固定。Scala 3.8 系は JDK 17+ 必須なので JDK は nix で揃える）。以降のコマンドは dev shell 内で実行する。
-- API(Scala): sbt ビルドルートは `apps/api`。`cd apps/api` してから `sbt compile` / `sbt test`。集約カバレッジ取得は `sbt clean` 後、Firestore エミュレータ内で `firebase emulators:exec --only firestore --project demo-morecat 'sbt -batch -no-colors coverage domain/test application/test infrastructure/test "infrastructure / FirestoreIntegration / test" coverageAggregate'`（HTML は `target/scala-*/scoverage-report/`）。純粋ドメインだけは `sbt domain/test`。エミュレータ統合テストだけなら `firebase emulators:exec --only firestore --project demo-morecat 'sbt -batch -no-colors "infrastructure / FirestoreIntegration / test"'`。`api/run` 等は今後追加。
+- API(Scala): sbt ビルドルートは `apps/api`。`cd apps/api` してから `sbt compile` / `sbt test`。集約カバレッジ取得は `sbt clean` 後、Firestore エミュレータ内で `firebase emulators:exec --only firestore --project demo-morecat 'sbt -batch -no-colors coverage domain/test application/test infrastructure/test bootstrap/test "infrastructure / FirestoreIntegration / test" coverageAggregate'`（HTML は `target/scala-*/scoverage-report/`）。純粋ドメインだけは `sbt domain/test`。エミュレータ統合テストだけなら `firebase emulators:exec --only firestore --project demo-morecat 'sbt -batch -no-colors "infrastructure / FirestoreIntegration / test"'`。サーバ起動は `MORECAT_BEARER_TOKEN=... sbt bootstrap/run`。
 - RMU(Rust): `cd apps/rmu` で `cargo build` / `cargo test`（実装はタスク3以降）。
 - UI: `apps/ui` で `pnpm install`、各 app で `pnpm dev` / `pnpm build` / `pnpm test` / `pnpm lint`。
 - 型生成: API の OpenAPI から `packages/api-client` を再生成（`pnpm gen:api`）。

--- a/apps/api/bootstrap/README.md
+++ b/apps/api/bootstrap/README.md
@@ -11,3 +11,41 @@ API の JVM エントリポイント。環境変数・Google Cloud client・infr
 - `PORT`: HTTP listen port（未指定時 `8080`。Cloud Run が設定する値を使用）
 
 Firestore は Application Default Credentials と `FIRESTORE_EMULATOR_HOST` を含む Google Cloud SDK 標準設定を利用する。
+
+## ローカル起動
+
+リポジトリルートで開発環境に入る。
+
+```sh
+nix develop
+```
+
+同じ dev shell 内の2つのターミナルを使う。先にターミナル1で Firestore emulator を起動する。
+
+```sh
+# terminal 1: repository root
+firebase emulators:start --only firestore --project demo-morecat
+```
+
+Firestore emulator が `127.0.0.1:8080` を使うため、ターミナル2では API を `8081` で起動する。
+
+```sh
+# terminal 2: repository root
+cd apps/api
+FIRESTORE_EMULATOR_HOST=127.0.0.1:8080 \
+GOOGLE_CLOUD_PROJECT=demo-morecat \
+PORT=8081 \
+MORECAT_BEARER_TOKEN=local-dev-token \
+sbt bootstrap/run
+```
+
+下書き作成 endpoint の疎通を確認する。
+
+```sh
+curl -i -X POST http://127.0.0.1:8081/articles \
+  -H 'Authorization: Bearer local-dev-token' \
+  -H 'Content-Type: application/json' \
+  --data '{"slug":"hello-world","title":"Hello","body":"# Hello"}'
+```
+
+成功時は `201 Created` と UUIDv7 の `articleId` を返す。Firestore emulator のデータは <http://127.0.0.1:4000/firestore> で確認できる。終了時は両ターミナルで `Ctrl-C` を入力する。

--- a/apps/api/bootstrap/README.md
+++ b/apps/api/bootstrap/README.md
@@ -1,0 +1,9 @@
+# apps/api/bootstrap
+
+API の JVM エントリポイント。環境変数・Google Cloud client・infrastructure adapter・application service を配線し、zio-http server を起動する。
+
+必須環境変数:
+
+- `MORECAT_BEARER_TOKEN`: command endpoint で検証する Bearer token
+
+Firestore は Application Default Credentials と `FIRESTORE_EMULATOR_HOST` を含む Google Cloud SDK 標準設定を利用する。

--- a/apps/api/bootstrap/README.md
+++ b/apps/api/bootstrap/README.md
@@ -6,4 +6,8 @@ API の JVM エントリポイント。環境変数・Google Cloud client・infr
 
 - `MORECAT_BEARER_TOKEN`: command endpoint で検証する Bearer token
 
+任意環境変数:
+
+- `PORT`: HTTP listen port（未指定時 `8080`。Cloud Run が設定する値を使用）
+
 Firestore は Application Default Credentials と `FIRESTORE_EMULATOR_HOST` を含む Google Cloud SDK 標準設定を利用する。

--- a/apps/api/bootstrap/src/main/scala/morecat/bootstrap/Main.scala
+++ b/apps/api/bootstrap/src/main/scala/morecat/bootstrap/Main.scala
@@ -15,6 +15,7 @@ import java.util.concurrent.TimeUnit
 // $COVERAGE-OFF$
 object Main extends ZIOAppDefault:
   private val BearerTokenEnv = "MORECAT_BEARER_TOKEN"
+  private val PortEnv = "PORT"
 
   override def run: ZIO[Any, Throwable, Unit] =
     ZIO.scoped {
@@ -25,6 +26,13 @@ object Main extends ZIOAppDefault:
         authenticator <- ZIO
           .fromEither(BearerTokenAuthenticator.make(token))
           .mapError(error => IllegalArgumentException(error.toString))
+        port <- System.env(PortEnv).flatMap {
+          case None        => ZIO.succeed(8080)
+          case Some(value) =>
+            ZIO
+              .fromOption(value.toIntOption.filter(port => port > 0 && port <= 65535))
+              .orElseFail(IllegalArgumentException(s"$PortEnv must be a valid TCP port"))
+        }
         firestore <- ZIO.acquireRelease(
           ZIO.attempt(FirestoreOptions.getDefaultInstance.getService)
         )(service => ZIO.attempt(service.close()).orDie)
@@ -43,7 +51,7 @@ object Main extends ZIOAppDefault:
           commandService.createDraft,
         )
         app = ApiHttpApp(endpoint)
-        _ <- Server.serve(app.handler.toRoutes).provide(Server.default)
+        _ <- Server.serve(app.handler.toRoutes).provide(Server.defaultWithPort(port))
       yield ()
     }
 // $COVERAGE-ON$

--- a/apps/api/bootstrap/src/main/scala/morecat/bootstrap/Main.scala
+++ b/apps/api/bootstrap/src/main/scala/morecat/bootstrap/Main.scala
@@ -1,0 +1,49 @@
+package morecat.bootstrap
+
+import com.google.cloud.firestore.FirestoreOptions
+import morecat.application.*
+import morecat.infrastructure.auth.BearerTokenAuthenticator
+import morecat.infrastructure.firestore.*
+import morecat.infrastructure.http.{ApiHttpApp, CommandSecurity, CreateArticleEndpoint}
+import morecat.infrastructure.id.UuidV7ArticleIdGenerator
+import zio.*
+import zio.http.Server
+
+import java.util.concurrent.TimeUnit
+
+// Live resource wiring is verified by compilation and local smoke tests.
+// $COVERAGE-OFF$
+object Main extends ZIOAppDefault:
+  private val BearerTokenEnv = "MORECAT_BEARER_TOKEN"
+
+  override def run: ZIO[Any, Throwable, Unit] =
+    ZIO.scoped {
+      for
+        token <- System
+          .env(BearerTokenEnv)
+          .someOrFail(IllegalStateException(s"$BearerTokenEnv is required"))
+        authenticator <- ZIO
+          .fromEither(BearerTokenAuthenticator.make(token))
+          .mapError(error => IllegalArgumentException(error.toString))
+        firestore <- ZIO.acquireRelease(
+          ZIO.attempt(FirestoreOptions.getDefaultInstance.getService)
+        )(service => ZIO.attempt(service.close()).orDie)
+        documentClient = GoogleFirestoreDocumentClient(
+          GoogleFirestoreOperations.fromFirestore(firestore)
+        )
+        backend = FirestoreClientEventStoreBackend(documentClient)
+        eventStore = FirestoreArticleEventStore(backend)
+        clock = new ServerClock:
+          override def nowMillis: UIO[Long] = Clock.currentTime(TimeUnit.MILLISECONDS)
+        commandService = ArticleCommandService(eventStore, clock)
+        security = CommandSecurity(authenticator)
+        endpoint = CreateArticleEndpoint(
+          security,
+          UuidV7ArticleIdGenerator(),
+          commandService.createDraft,
+        )
+        app = ApiHttpApp(endpoint)
+        _ <- Server.serve(app.handler.toRoutes).provide(Server.default)
+      yield ()
+    }
+// $COVERAGE-ON$

--- a/apps/api/build.sbt
+++ b/apps/api/build.sbt
@@ -29,7 +29,7 @@ ThisBuild / coverageFailOnMinimum := true
 
 lazy val root = project
   .in(file("."))
-  .aggregate(domain, application, infrastructure)
+  .aggregate(domain, application, infrastructure, bootstrap)
   .settings(
     name := "morecat-api",
     publish / skip := true,
@@ -82,4 +82,12 @@ lazy val infrastructure = project
     ),
     testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework"),
     inConfig(FirestoreIntegration)(Defaults.testSettings),
+  )
+
+lazy val bootstrap = project
+  .in(file("bootstrap"))
+  .dependsOn(infrastructure)
+  .settings(
+    name := "morecat-bootstrap",
+    libraryDependencies += "dev.zio" %% "zio" % zioVersion,
   )

--- a/apps/api/infrastructure/src/main/scala/morecat/infrastructure/http/ApiHttpApp.scala
+++ b/apps/api/infrastructure/src/main/scala/morecat/infrastructure/http/ApiHttpApp.scala
@@ -1,0 +1,24 @@
+package morecat.infrastructure.http
+
+import sttp.tapir.server.ziohttp.ZioHttpInterpreter
+import zio.*
+import zio.http.*
+
+final class ApiHttpApp(createArticleEndpoint: CreateArticleEndpoint):
+  private val endpointRoutes: Routes[Any, Response] =
+    ZioHttpInterpreter().toHttp(createArticleEndpoint.endpoint)
+
+  val handler: Handler[Scope, Nothing, Request, Response] =
+    Handler.fromFunctionZIO[Request](handle)
+
+  def handle(request: Request): ZIO[Scope, Nothing, Response] =
+    Handler
+      .asChunkBounded(request, ApiHttpApp.MaxRequestBodyBytes)
+      .runZIO(())
+      .foldZIO(
+        _ => ZIO.succeed(Response.status(Status.RequestEntityTooLarge)),
+        body => endpointRoutes.runZIO(request.withBody(Body.fromChunk(body))),
+      )
+
+object ApiHttpApp:
+  val MaxRequestBodyBytes: Int = 512 * 1024

--- a/apps/api/infrastructure/src/main/scala/morecat/infrastructure/http/ApiHttpApp.scala
+++ b/apps/api/infrastructure/src/main/scala/morecat/infrastructure/http/ApiHttpApp.scala
@@ -8,17 +8,19 @@ final class ApiHttpApp(createArticleEndpoint: CreateArticleEndpoint):
   private val endpointRoutes: Routes[Any, Response] =
     ZioHttpInterpreter().toHttp(createArticleEndpoint.endpoint)
 
-  val handler: Handler[Scope, Nothing, Request, Response] =
+  val handler: Handler[Any, Nothing, Request, Response] =
     Handler.fromFunctionZIO[Request](handle)
 
-  def handle(request: Request): ZIO[Scope, Nothing, Response] =
-    Handler
-      .asChunkBounded(request, ApiHttpApp.MaxRequestBodyBytes)
-      .runZIO(())
-      .foldZIO(
-        _ => ZIO.succeed(Response.status(Status.RequestEntityTooLarge)),
-        body => endpointRoutes.runZIO(request.withBody(Body.fromChunk(body))),
-      )
+  def handle(request: Request): UIO[Response] =
+    ZIO.scoped {
+      Handler
+        .asChunkBounded(request, ApiHttpApp.MaxRequestBodyBytes)
+        .runZIO(())
+        .foldZIO(
+          _ => ZIO.succeed(Response.status(Status.RequestEntityTooLarge)),
+          body => endpointRoutes.runZIO(request.withBody(Body.fromChunk(body))),
+        )
+    }
 
 object ApiHttpApp:
   val MaxRequestBodyBytes: Int = 512 * 1024

--- a/apps/api/infrastructure/src/test/scala/morecat/infrastructure/http/ApiHttpAppSpec.scala
+++ b/apps/api/infrastructure/src/test/scala/morecat/infrastructure/http/ApiHttpAppSpec.scala
@@ -1,0 +1,63 @@
+package morecat.infrastructure.http
+
+import morecat.application.*
+import morecat.domain.ArticleId
+import morecat.infrastructure.auth.BearerTokenAuthenticator
+import zio.*
+import zio.http.*
+import zio.stream.ZStream
+import zio.test.*
+
+object ApiHttpAppSpec extends ZIOSpecDefault:
+
+  private val generatedId =
+    ArticleId.fromString("018f4edc-1f5a-7c4b-aef9-000000000001")
+
+  private val idGenerator = new ArticleIdGenerator:
+    override def next: UIO[ArticleId] = ZIO.succeed(generatedId)
+
+  private val security = CommandSecurity(
+    BearerTokenAuthenticator.make("expected-token").toOption.get
+  )
+
+  private def request(body: Body): Request =
+    Request
+      .post(URL.decode("http://localhost/articles").toOption.get, body)
+      .addHeader(Header.ContentType(MediaType.application.json))
+      .addHeader(Header.Authorization.Bearer("expected-token"))
+
+  def spec = suite("ApiHttpApp")(
+    test("routes a request within the body limit to the create endpoint") {
+      val json = """{"slug":"hello-world","title":"Hello","body":"body"}"""
+
+      for
+        called <- Ref.make(false)
+        endpoint = CreateArticleEndpoint(
+          security,
+          idGenerator,
+          _ => called.set(true),
+        )
+        app = ApiHttpApp(endpoint)
+        response <- app.handle(request(Body.fromString(json)))
+        wasCalled <- called.get
+      yield assertTrue(response.status == Status.Created, wasCalled)
+    },
+    test("rejects an oversized chunked request before calling the command") {
+      val oversizedJson =
+        s"""{"slug":"hello-world","title":"Hello","body":"${"a" * ApiHttpApp.MaxRequestBodyBytes}"}"""
+
+      for
+        called <- Ref.make(false)
+        endpoint = CreateArticleEndpoint(
+          security,
+          idGenerator,
+          _ => called.set(true),
+        )
+        app = ApiHttpApp(endpoint)
+        response <- app.handle(
+          request(Body.fromStreamChunked(ZStream.fromIterable(oversizedJson.getBytes)))
+        )
+        wasCalled <- called.get
+      yield assertTrue(response.status == Status.RequestEntityTooLarge, !wasCalled)
+    }
+  )

--- a/apps/api/infrastructure/src/test/scala/morecat/infrastructure/http/ApiHttpAppSpec.scala
+++ b/apps/api/infrastructure/src/test/scala/morecat/infrastructure/http/ApiHttpAppSpec.scala
@@ -38,7 +38,7 @@ object ApiHttpAppSpec extends ZIOSpecDefault:
           _ => called.set(true),
         )
         app = ApiHttpApp(endpoint)
-        response <- app.handle(request(Body.fromString(json)))
+        response <- app.handler.runZIO(request(Body.fromString(json)))
         wasCalled <- called.get
       yield assertTrue(response.status == Status.Created, wasCalled)
     },


### PR DESCRIPTION
## 概要

- `POST /articles` を zio-http server route へ接続
- JSON decode 前に request body を最大 512 KiB で打ち切り、超過時は `413` を返す
- Content-Length のない chunked request も bounded consumer で制限
- `bootstrap` sbt subproject と実行 entrypoint を追加
- Bearer token、Firestore、UUIDv7 generator、command service を配線
- Cloud Run の `PORT` 環境変数へ対応
- CI の coverage 対象に bootstrap を追加
- 人間向けの emulator / API 起動手順と疎通用 curl を README に追加

## 目的

PR #95 で追加した型付き endpoint を実サーバから到達可能にし、レビューで残した OOME / DoS 対策を JSON materialization より前の HTTP server 境界で実装します。

## 検証

```sh
firebase emulators:exec --only firestore --project demo-morecat 'sbt -batch -no-colors coverage domain/test application/test infrastructure/test bootstrap/test "infrastructure / FirestoreIntegration / test" coverageAggregate'
```

- unit tests: 97 passed
- Firestore integration tests: 6 passed
- statement coverage: 100.00%
- branch coverage: 100.00%
- `bootstrap/compile`: success
- Firestore emulator と API server を同時起動し、実 `POST /articles` が `201 Created` と UUIDv7 article ID を返すことを確認

## レビュー用セットアップ

[bootstrap README](apps/api/bootstrap/README.md) の「ローカル起動」に従ってください。Firestore emulator は `8080`、API はローカルでは `8081` を使用します。