### PR TITLE
feat(api): add publish article endpoint

### DIFF
--- a/apps/api/bootstrap/src/main/scala/morecat/bootstrap/Main.scala
+++ b/apps/api/bootstrap/src/main/scala/morecat/bootstrap/Main.scala
@@ -4,7 +4,12 @@ import com.google.cloud.firestore.FirestoreOptions
 import morecat.application.*
 import morecat.infrastructure.auth.BearerTokenAuthenticator
 import morecat.infrastructure.firestore.*
-import morecat.infrastructure.http.{ApiHttpApp, CommandSecurity, CreateArticleEndpoint}
+import morecat.infrastructure.http.{
+  ApiHttpApp,
+  CommandSecurity,
+  CreateArticleEndpoint,
+  PublishArticleEndpoint
+}
 import morecat.infrastructure.id.UuidV7ArticleIdGenerator
 import zio.*
 import zio.http.Server
@@ -50,7 +55,8 @@ object Main extends ZIOAppDefault:
           UuidV7ArticleIdGenerator(),
           commandService.createDraft,
         )
-        app = ApiHttpApp(endpoint)
+        publishEndpoint = PublishArticleEndpoint(security, commandService.publish)
+        app = ApiHttpApp(endpoint, publishEndpoint)
         _ <- Server.serve(app.handler.toRoutes).provide(Server.defaultWithPort(port))
       yield ()
     }

--- a/apps/api/infrastructure/src/main/scala/morecat/infrastructure/http/ApiHttpApp.scala
+++ b/apps/api/infrastructure/src/main/scala/morecat/infrastructure/http/ApiHttpApp.scala
@@ -4,9 +4,14 @@ import sttp.tapir.server.ziohttp.ZioHttpInterpreter
 import zio.*
 import zio.http.*
 
-final class ApiHttpApp(createArticleEndpoint: CreateArticleEndpoint):
+final class ApiHttpApp(
+  createArticleEndpoint: CreateArticleEndpoint,
+  publishArticleEndpoint: PublishArticleEndpoint,
+):
   private val endpointRoutes: Routes[Any, Response] =
-    ZioHttpInterpreter().toHttp(createArticleEndpoint.endpoint)
+    ZioHttpInterpreter().toHttp(
+      List(createArticleEndpoint.endpoint, publishArticleEndpoint.endpoint)
+    )
 
   val handler: Handler[Any, Nothing, Request, Response] =
     Handler.fromFunctionZIO[Request](handle)

--- a/apps/api/infrastructure/src/main/scala/morecat/infrastructure/http/PublishArticleEndpoint.scala
+++ b/apps/api/infrastructure/src/main/scala/morecat/infrastructure/http/PublishArticleEndpoint.scala
@@ -1,0 +1,63 @@
+package morecat.infrastructure.http
+
+import morecat.application.*
+import morecat.domain.ArticleId
+import sttp.model.StatusCode
+import sttp.tapir.Schema
+import sttp.tapir.json.zio.*
+import sttp.tapir.ztapir.*
+import zio.*
+import zio.json.*
+import zio.json.ast.Json
+
+import java.util.UUID
+
+final case class PublishArticleRequest(expectedVersion: Long) derives JsonEncoder, Schema
+
+object PublishArticleRequest:
+  private final case class Wire(expectedVersion: Long) derives JsonDecoder
+  private val ExpectedField = "expectedVersion"
+
+  given JsonDecoder[PublishArticleRequest] = JsonDecoder[Json].mapOrFail {
+    case obj: Json.Obj
+        if obj.fields.size == 1 && obj.fields.headOption.exists(_._1 == ExpectedField) =>
+      obj.toJson.fromJson[Wire].map(wire => PublishArticleRequest(wire.expectedVersion))
+    case _: Json.Obj => Left("publish article request contains unknown or missing fields")
+    case _           => Left("publish article request must be a JSON object")
+  }
+
+final class PublishArticleEndpoint(
+  security: CommandSecurity,
+  publish: PublishArticleCommand => IO[CommandError, PublishResult],
+):
+  val endpoint = security.endpoint.post
+    .in("articles" / path[String]("articleId") / "publish")
+    .in(jsonBody[PublishArticleRequest])
+    .out(statusCode(StatusCode.NoContent))
+    .serverLogic[Any](_ => input => execute(input._1, input._2).flatMap(ZIO.fromEither))
+
+  def execute(
+    rawArticleId: String,
+    request: PublishArticleRequest,
+  ): UIO[Either[StatusCode, Unit]] =
+    (for
+      articleId <- parseArticleId(rawArticleId)
+      _ <- ZIO.unless(request.expectedVersion >= 0)(ZIO.fail(StatusCode.BadRequest))
+      _ <- publish(PublishArticleCommand(articleId, request.expectedVersion)).mapError(toStatusCode)
+    yield ()).either
+
+  private def parseArticleId(value: String): IO[StatusCode, ArticleId] =
+    ZIO
+      .attempt(UUID.fromString(value))
+      .filterOrFail(uuid => uuid.version() == 7 && uuid.toString == value)(StatusCode.BadRequest)
+      .map(uuid => ArticleId.fromString(uuid.toString))
+      .mapError(_ => StatusCode.BadRequest)
+
+  private def toStatusCode(error: CommandError): StatusCode =
+    error match
+      case CommandError.InvalidDraft(_)  => StatusCode.BadRequest
+      case CommandError.SlugConflict     => StatusCode.Conflict
+      case CommandError.VersionConflict  => StatusCode.Conflict
+      case CommandError.ArticleNotFound  => StatusCode.NotFound
+      case CommandError.StoreFailure     => StatusCode.InternalServerError
+      case CommandError.StoreUnavailable => StatusCode.ServiceUnavailable

--- a/apps/api/infrastructure/src/test/scala/morecat/infrastructure/http/ApiHttpAppSpec.scala
+++ b/apps/api/infrastructure/src/test/scala/morecat/infrastructure/http/ApiHttpAppSpec.scala
@@ -20,6 +20,11 @@ object ApiHttpAppSpec extends ZIOSpecDefault:
     BearerTokenAuthenticator.make("expected-token").toOption.get
   )
 
+  private val publishEndpoint = PublishArticleEndpoint(
+    security,
+    _ => ZIO.succeed(PublishResult.Published),
+  )
+
   private def request(body: Body): Request =
     Request
       .post(URL.decode("http://localhost/articles").toOption.get, body)
@@ -37,7 +42,7 @@ object ApiHttpAppSpec extends ZIOSpecDefault:
           idGenerator,
           _ => called.set(true),
         )
-        app = ApiHttpApp(endpoint)
+        app = ApiHttpApp(endpoint, publishEndpoint)
         response <- app.handler.runZIO(request(Body.fromString(json)))
         wasCalled <- called.get
       yield assertTrue(response.status == Status.Created, wasCalled)
@@ -53,7 +58,7 @@ object ApiHttpAppSpec extends ZIOSpecDefault:
           idGenerator,
           _ => called.set(true),
         )
-        app = ApiHttpApp(endpoint)
+        app = ApiHttpApp(endpoint, publishEndpoint)
         response <- app.handle(
           request(Body.fromStreamChunked(ZStream.fromIterable(oversizedJson.getBytes)))
         )

--- a/apps/api/infrastructure/src/test/scala/morecat/infrastructure/http/PublishArticleEndpointSpec.scala
+++ b/apps/api/infrastructure/src/test/scala/morecat/infrastructure/http/PublishArticleEndpointSpec.scala
@@ -1,0 +1,102 @@
+package morecat.infrastructure.http
+
+import morecat.application.*
+import morecat.domain.ArticleId
+import morecat.infrastructure.auth.BearerTokenAuthenticator
+import sttp.model.StatusCode
+import sttp.tapir.server.ziohttp.ZioHttpInterpreter
+import zio.*
+import zio.http.{Body, Header, MediaType, Request, Response, Routes, Status, URL}
+import zio.json.*
+import zio.test.*
+
+object PublishArticleEndpointSpec extends ZIOSpecDefault:
+
+  private val rawArticleId = "018f4edc-1f5a-7c4b-aef9-000000000001"
+  private val security = CommandSecurity(
+    BearerTokenAuthenticator.make("expected-token").toOption.get
+  )
+
+  def spec = suite("PublishArticleEndpoint")(
+    test("publishes the article with the required expected version") {
+      for
+        recorded <- Ref.make(Option.empty[PublishArticleCommand])
+        endpoint = PublishArticleEndpoint(
+          security,
+          command => recorded.set(Some(command)).as(PublishResult.Published),
+        )
+        result <- endpoint.execute(rawArticleId, PublishArticleRequest(expectedVersion = 1L))
+        command <- recorded.get
+      yield assertTrue(
+        result == Right(()),
+        command.contains(
+          PublishArticleCommand(ArticleId.fromString(rawArticleId), expectedVersion = 1L)
+        ),
+      )
+    },
+    test("rejects invalid article IDs and negative versions before publishing") {
+      for
+        called <- Ref.make(false)
+        endpoint = PublishArticleEndpoint(
+          security,
+          _ => called.set(true).as(PublishResult.Published),
+        )
+        invalidId <- endpoint.execute("not-a-uuid", PublishArticleRequest(1L))
+        wrongVersion <- endpoint.execute(
+          "550e8400-e29b-41d4-a716-446655440000",
+          PublishArticleRequest(1L),
+        )
+        negativeVersion <- endpoint.execute(rawArticleId, PublishArticleRequest(-1L))
+        wasCalled <- called.get
+      yield assertTrue(
+        invalidId == Left(StatusCode.BadRequest),
+        wrongVersion == Left(StatusCode.BadRequest),
+        negativeVersion == Left(StatusCode.BadRequest),
+        !wasCalled,
+      )
+    },
+    test("maps command errors to HTTP statuses") {
+      val cases = List(
+        CommandError.InvalidDraft(Chunk.empty) -> StatusCode.BadRequest,
+        CommandError.SlugConflict -> StatusCode.Conflict,
+        CommandError.VersionConflict -> StatusCode.Conflict,
+        CommandError.ArticleNotFound -> StatusCode.NotFound,
+        CommandError.StoreFailure -> StatusCode.InternalServerError,
+        CommandError.StoreUnavailable -> StatusCode.ServiceUnavailable,
+      )
+
+      ZIO
+        .foreach(cases) { case (error, status) =>
+          val endpoint = PublishArticleEndpoint(security, _ => ZIO.fail(error))
+          assertZIO(endpoint.execute(rawArticleId, PublishArticleRequest(1L)))(
+            Assertion.isLeft(Assertion.equalTo(status))
+          )
+        }
+        .map(_.reduce(_ && _))
+    },
+    test("serves the authenticated publish endpoint as no content") {
+      val endpoint = PublishArticleEndpoint(
+        security,
+        _ => ZIO.succeed(PublishResult.Published),
+      )
+      val routes: Routes[Any, Response] = ZioHttpInterpreter().toHttp(endpoint.endpoint)
+      val request = Request
+        .post(
+          URL.decode(s"http://localhost/articles/$rawArticleId/publish").toOption.get,
+          Body.fromString("""{"expectedVersion":1}"""),
+        )
+        .addHeader(Header.ContentType(MediaType.application.json))
+        .addHeader(Header.Authorization.Bearer("expected-token"))
+
+      assertZIO(routes.runZIO(request).map(_.status))(
+        Assertion.equalTo(Status.NoContent)
+      )
+    },
+    test("rejects unknown, missing, and non-object publish requests") {
+      assertTrue(
+        """{"expectedVersion":1,"force":true}""".fromJson[PublishArticleRequest].isLeft,
+        "{}".fromJson[PublishArticleRequest].isLeft,
+        "[]".fromJson[PublishArticleRequest].isLeft,
+      )
+    },
+  )


### PR DESCRIPTION
## 概要

認証付きの `POST /articles/{articleId}/publish` エンドポイントを追加します。

## 変更内容

- publish リクエストの `expectedVersion` を strict JSON として検証
- article ID を canonical UUIDv7 として検証
- publish command の結果を `204 No Content` として返却
- command error を 400 / 404 / 409 / 500 / 503 にマッピング
- zio-http app と bootstrap に publish endpoint を配線
- endpoint、認証経路、入力検証、エラーマッピングのテストを追加

## 関連

- `docs/slice-1-plan.md` の publish command HTTP 境界

## レビュー用セットアップ

```sh
nix develop
cd apps/api
firebase emulators:exec --only firestore --project demo-morecat 'sbt -batch -no-colors coverage domain/test application/test infrastructure/test bootstrap/test "infrastructure / FirestoreIntegration / test" coverageAggregate'
```

## 検証

- unit tests: 102 passed
- Firestore integration tests: 6 passed
- statement coverage: 100%
- branch coverage: 100%