### PR TITLE
Add RMU Cloud Run service entrypoint

### DIFF
--- a/apps/rmu/Cargo.toml
+++ b/apps/rmu/Cargo.toml
@@ -20,7 +20,7 @@ serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.150"
 sha2 = "0.11.0"
 sqlx = { version = "0.9.0", default-features = false, features = ["postgres", "runtime-tokio", "uuid"] }
-tokio = { version = "1.52.3", features = ["macros", "net", "rt-multi-thread"] }
+tokio = { version = "1.52.3", features = ["macros", "net", "rt-multi-thread", "signal"] }
 uuid = "1.23.5"
 
 [dev-dependencies]

--- a/apps/rmu/README.md
+++ b/apps/rmu/README.md
@@ -14,7 +14,7 @@ API の Scala domain とはコード共有せず、event wire schema と project
 
 - `PORT`: HTTP listen port（未指定時 `8080`。Cloud Run が設定する値を使用）
 
-Firestore は Application Default Credentials と `FIRESTORE_EMULATOR_HOST` を含む Google Cloud SDK 標準設定を利用する。`SIGINT` を受けると処理中の HTTP request を待ってから終了する。
+Firestore は Application Default Credentials と `FIRESTORE_EMULATOR_HOST` を含む Google Cloud SDK 標準設定を利用する。`SIGINT` または `SIGTERM` を受けると処理中の HTTP request を待ってから終了する。
 
 ## Local startup
 

--- a/apps/rmu/README.md
+++ b/apps/rmu/README.md
@@ -3,6 +3,49 @@
 Firestore の Article event を Eventarc から受信し、Postgres の read model を更新する Rust サービス。
 API の Scala domain とはコード共有せず、event wire schema と projection fixture を契約として扱う。
 
+## Runtime configuration
+
+必須環境変数:
+
+- `GOOGLE_CLOUD_PROJECT`: event store を読む Firestore project ID
+- `DATABASE_URL`: Postgres 接続 URL（例: `postgres://morecat:password@127.0.0.1:5432/morecat`）
+
+任意環境変数:
+
+- `PORT`: HTTP listen port（未指定時 `8080`。Cloud Run が設定する値を使用）
+
+Firestore は Application Default Credentials と `FIRESTORE_EMULATOR_HOST` を含む Google Cloud SDK 標準設定を利用する。`SIGINT` を受けると処理中の HTTP request を待ってから終了する。
+
+## Local startup
+
+Postgres に次の migration を順番に適用しておく。
+
+- `apps/api/infrastructure/src/main/resources/db/migration/V1__create_articles.sql`
+- `apps/api/infrastructure/src/main/resources/db/migration/V2__create_rmu_dead_letters.sql`
+
+リポジトリルートで `nix develop .#rust` に入り、2つのターミナルを使う。ターミナル1で Firestore emulator を起動する。
+
+```sh
+# terminal 1: repository root
+firebase emulators:start \
+  --config apps/api/firebase.json \
+  --only firestore \
+  --project demo-morecat
+```
+
+Firestore emulator が `127.0.0.1:8080` を使うため、ターミナル2では RMU を `8081` で起動する。
+
+```sh
+# terminal 2: repository root
+FIRESTORE_EMULATOR_HOST=127.0.0.1:8080 \
+GOOGLE_CLOUD_PROJECT=demo-morecat \
+DATABASE_URL=postgres://morecat:local-dev-password@127.0.0.1:5432/morecat \
+PORT=8081 \
+cargo run --manifest-path apps/rmu/Cargo.toml
+```
+
+終了時は両ターミナルで `Ctrl-C` を入力する。
+
 ## Development
 
 リポジトリルートで Rust 用 dev shell に入り、テストを実行する。

--- a/apps/rmu/src/bootstrap.rs
+++ b/apps/rmu/src/bootstrap.rs
@@ -1,4 +1,6 @@
-use std::{collections::HashMap, ffi::OsString, fmt, future::Future, pin::Pin, sync::Arc};
+use std::{
+    collections::HashMap, ffi::OsString, fmt, future::Future, io::Write, pin::Pin, sync::Arc,
+};
 
 use axum::Router;
 use sqlx::postgres::{PgConnectOptions, PgPoolOptions};
@@ -89,14 +91,29 @@ pub async fn run(
     let listener = TcpListener::bind(("0.0.0.0", port))
         .await
         .map_err(listener_error)?;
+    let address = listener
+        .local_addr()
+        .expect("bound RMU listener must have a local address");
+    let mut stdout = std::io::stdout().lock();
+    writeln!(stdout, "RMU listening on {address}").expect("failed to write RMU readiness");
+    stdout.flush().expect("failed to flush RMU readiness");
+    drop(stdout);
     axum::serve(listener, app)
         .with_graceful_shutdown(shutdown)
         .await
         .map_err(server_error)
 }
 
-fn listener_error(_error: std::io::Error) -> String {
-    "failed to bind RMU listener".to_owned()
+fn listener_error(error: std::io::Error) -> String {
+    match error.kind() {
+        std::io::ErrorKind::AddrInUse => {
+            "failed to bind RMU listener: address already in use".to_owned()
+        }
+        std::io::ErrorKind::PermissionDenied => {
+            "failed to bind RMU listener: permission denied".to_owned()
+        }
+        _ => "failed to bind RMU listener".to_owned(),
+    }
 }
 
 fn server_error(_error: std::io::Error) -> String {
@@ -214,7 +231,15 @@ mod tests {
     }
 
     #[test]
-    fn redacts_listener_and_server_error_details() {
+    fn identifies_safe_listener_error_kinds_and_redacts_other_details() {
+        assert_eq!(
+            listener_error(std::io::ErrorKind::AddrInUse.into()),
+            "failed to bind RMU listener: address already in use"
+        );
+        assert_eq!(
+            listener_error(std::io::ErrorKind::PermissionDenied.into()),
+            "failed to bind RMU listener: permission denied"
+        );
         assert_eq!(
             listener_error(std::io::Error::other("listener secret")),
             "failed to bind RMU listener"
@@ -379,7 +404,10 @@ mod integration_tests {
             Box::pin(std::future::ready(())),
         )
         .await;
-        assert_eq!(bind_error, Err("failed to bind RMU listener".to_owned()));
+        assert_eq!(
+            bind_error,
+            Err("failed to bind RMU listener: address already in use".to_owned())
+        );
     }
 
     async fn seed_draft_event() {

--- a/apps/rmu/src/bootstrap.rs
+++ b/apps/rmu/src/bootstrap.rs
@@ -1,7 +1,8 @@
-use std::{collections::HashMap, ffi::OsString, fmt, sync::Arc};
+use std::{collections::HashMap, ffi::OsString, fmt, future::Future, pin::Pin, sync::Arc};
 
 use axum::Router;
 use sqlx::postgres::{PgConnectOptions, PgPoolOptions};
+use tokio::net::TcpListener;
 
 use crate::{
     eventarc::{EventActions, router},
@@ -14,6 +15,7 @@ use crate::{
 pub struct RmuConfig {
     pub project_id: String,
     pub database_url: String,
+    pub port: u16,
 }
 
 impl fmt::Debug for RmuConfig {
@@ -22,20 +24,29 @@ impl fmt::Debug for RmuConfig {
             .debug_struct("RmuConfig")
             .field("project_id", &self.project_id)
             .field("database_url", &"[REDACTED]")
+            .field("port", &self.port)
             .finish()
     }
 }
 
 impl RmuConfig {
-    pub fn from_vars<I>(vars: I) -> Result<Self, String>
-    where
-        I: IntoIterator<Item = (OsString, OsString)>,
-    {
+    pub fn from_vars(vars: Vec<(OsString, OsString)>) -> Result<Self, String> {
         let vars: HashMap<_, _> = vars.into_iter().collect();
         Ok(Self {
             project_id: required_var(&vars, "GOOGLE_CLOUD_PROJECT")?,
             database_url: required_var(&vars, "DATABASE_URL")?,
+            port: port(&vars)?,
         })
+    }
+}
+
+fn port(vars: &HashMap<OsString, OsString>) -> Result<u16, String> {
+    match vars.get(&OsString::from("PORT")) {
+        None => Ok(8080),
+        Some(value) => value
+            .to_str()
+            .and_then(|value| value.parse().ok())
+            .ok_or_else(|| "invalid PORT".to_owned()),
     }
 }
 
@@ -68,13 +79,37 @@ pub async fn build_live_router(config: RmuConfig) -> Result<Router, String> {
     Ok(router(actions))
 }
 
+pub async fn run(
+    vars: Vec<(OsString, OsString)>,
+    shutdown: Pin<Box<dyn Future<Output = ()> + Send + 'static>>,
+) -> Result<(), String> {
+    let config = RmuConfig::from_vars(vars)?;
+    let port = config.port;
+    let app = build_live_router(config).await?;
+    let listener = TcpListener::bind(("0.0.0.0", port))
+        .await
+        .map_err(listener_error)?;
+    axum::serve(listener, app)
+        .with_graceful_shutdown(shutdown)
+        .await
+        .map_err(server_error)
+}
+
+fn listener_error(_error: std::io::Error) -> String {
+    "failed to bind RMU listener".to_owned()
+}
+
+fn server_error(_error: std::io::Error) -> String {
+    "RMU server failed".to_owned()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
     fn loads_the_live_service_configuration() {
-        let result = RmuConfig::from_vars([
+        let result = RmuConfig::from_vars(vec![
             ("UNRELATED".into(), "ignored".into()),
             ("GOOGLE_CLOUD_PROJECT".into(), "demo-morecat".into()),
             (
@@ -88,6 +123,7 @@ mod tests {
             Ok(RmuConfig {
                 project_id: "demo-morecat".to_owned(),
                 database_url: "postgres://user:password@localhost/morecat".to_owned(),
+                port: 8080,
             })
         );
     }
@@ -95,11 +131,11 @@ mod tests {
     #[test]
     fn rejects_missing_empty_and_non_utf8_configuration() {
         assert_eq!(
-            RmuConfig::from_vars([]),
+            RmuConfig::from_vars(Vec::new()),
             Err("missing GOOGLE_CLOUD_PROJECT".to_owned())
         );
         assert_eq!(
-            RmuConfig::from_vars([
+            RmuConfig::from_vars(vec![
                 ("GOOGLE_CLOUD_PROJECT".into(), "demo-morecat".into()),
                 ("DATABASE_URL".into(), "".into()),
             ]),
@@ -111,7 +147,7 @@ mod tests {
             use std::os::unix::ffi::OsStringExt;
 
             assert_eq!(
-                RmuConfig::from_vars([
+                RmuConfig::from_vars(vec![
                     (
                         "GOOGLE_CLOUD_PROJECT".into(),
                         OsString::from_vec(vec![0xff])
@@ -127,15 +163,65 @@ mod tests {
     }
 
     #[test]
+    fn loads_and_validates_an_explicit_port() {
+        let vars = |port: OsString| {
+            [
+                ("GOOGLE_CLOUD_PROJECT".into(), "demo-morecat".into()),
+                (
+                    "DATABASE_URL".into(),
+                    "postgres://user:password@localhost/morecat".into(),
+                ),
+                ("PORT".into(), port),
+            ]
+        };
+
+        assert_eq!(
+            RmuConfig::from_vars(vars("9090".into()).into())
+                .unwrap()
+                .port,
+            9090
+        );
+        for invalid in ["".into(), "-1".into(), "65536".into()] {
+            assert_eq!(
+                RmuConfig::from_vars(vars(invalid).into()),
+                Err("invalid PORT".to_owned())
+            );
+        }
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::ffi::OsStringExt;
+
+            assert_eq!(
+                RmuConfig::from_vars(vars(OsString::from_vec(vec![0xff])).into()),
+                Err("invalid PORT".to_owned())
+            );
+        }
+    }
+
+    #[test]
     fn redacts_database_credentials_from_debug_output() {
         let config = RmuConfig {
             project_id: "demo-morecat".to_owned(),
             database_url: "postgres://user:secret@localhost/morecat".to_owned(),
+            port: 8080,
         };
 
         assert_eq!(
             format!("{config:?}"),
-            "RmuConfig { project_id: \"demo-morecat\", database_url: \"[REDACTED]\" }"
+            "RmuConfig { project_id: \"demo-morecat\", database_url: \"[REDACTED]\", port: 8080 }"
+        );
+    }
+
+    #[test]
+    fn redacts_listener_and_server_error_details() {
+        assert_eq!(
+            listener_error(std::io::Error::other("listener secret")),
+            "failed to bind RMU listener"
+        );
+        assert_eq!(
+            server_error(std::io::Error::other("server secret")),
+            "RMU server failed"
         );
     }
 }
@@ -185,6 +271,7 @@ mod integration_tests {
         let router = build_live_router(RmuConfig {
             project_id: "demo-morecat".to_owned(),
             database_url,
+            port: 8080,
         })
         .await;
 
@@ -215,6 +302,7 @@ mod integration_tests {
         let firestore_error = build_live_router(RmuConfig {
             project_id: String::new(),
             database_url: "postgres://user:secret@localhost/morecat".to_owned(),
+            port: 8080,
         })
         .await;
         assert!(matches!(
@@ -226,6 +314,7 @@ mod integration_tests {
         let postgres_error = build_live_router(RmuConfig {
             project_id: "demo-morecat".to_owned(),
             database_url: "postgres://user:secret@[invalid/morecat".to_owned(),
+            port: 8080,
         })
         .await;
         assert_eq!(
@@ -238,12 +327,59 @@ mod integration_tests {
         let connection_error = build_live_router(RmuConfig {
             project_id: "demo-morecat".to_owned(),
             database_url: invalid_credentials,
+            port: 8080,
         })
         .await;
         assert_eq!(
             connection_error.err(),
             Some("failed to connect to Postgres".to_owned())
         );
+
+        let run_error = run(
+            vec![
+                ("GOOGLE_CLOUD_PROJECT".into(), "demo-morecat".into()),
+                (
+                    "DATABASE_URL".into(),
+                    "postgres://user:secret@[invalid/morecat".into(),
+                ),
+            ],
+            Box::pin(std::future::ready(())),
+        )
+        .await;
+        assert_eq!(
+            run_error,
+            Err("failed to connect to Postgres: invalid DATABASE_URL".to_owned())
+        );
+    }
+
+    #[tokio::test]
+    async fn binds_and_stops_the_live_service() {
+        let (_container, _pool, database_url) = migrated_postgres().await;
+
+        let result = run(
+            vec![
+                ("GOOGLE_CLOUD_PROJECT".into(), "demo-morecat".into()),
+                ("DATABASE_URL".into(), database_url.clone().into()),
+                ("PORT".into(), "0".into()),
+            ],
+            Box::pin(std::future::ready(())),
+        )
+        .await;
+
+        assert_eq!(result, Ok(()));
+
+        let occupied = TcpListener::bind(("0.0.0.0", 0)).await.unwrap();
+        let port = occupied.local_addr().unwrap().port();
+        let bind_error = run(
+            vec![
+                ("GOOGLE_CLOUD_PROJECT".into(), "demo-morecat".into()),
+                ("DATABASE_URL".into(), database_url.into()),
+                ("PORT".into(), port.to_string().into()),
+            ],
+            Box::pin(std::future::ready(())),
+        )
+        .await;
+        assert_eq!(bind_error, Err("failed to bind RMU listener".to_owned()));
     }
 
     async fn seed_draft_event() {

--- a/apps/rmu/src/main.rs
+++ b/apps/rmu/src/main.rs
@@ -1,10 +1,19 @@
 #[tokio::main]
 async fn main() -> Result<(), String> {
-    morecat_rmu::bootstrap::run(
-        std::env::vars_os().collect(),
-        Box::pin(async {
-            let _ = tokio::signal::ctrl_c().await;
-        }),
-    )
-    .await
+    morecat_rmu::bootstrap::run(std::env::vars_os().collect(), Box::pin(shutdown_signal())).await
+}
+
+#[cfg(unix)]
+async fn shutdown_signal() {
+    let mut terminate = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+        .expect("failed to install SIGTERM handler");
+    tokio::select! {
+        _ = tokio::signal::ctrl_c() => {}
+        _ = terminate.recv() => {}
+    }
+}
+
+#[cfg(not(unix))]
+async fn shutdown_signal() {
+    let _ = tokio::signal::ctrl_c().await;
 }

--- a/apps/rmu/src/main.rs
+++ b/apps/rmu/src/main.rs
@@ -1,0 +1,10 @@
+#[tokio::main]
+async fn main() -> Result<(), String> {
+    morecat_rmu::bootstrap::run(
+        std::env::vars_os().collect(),
+        Box::pin(async {
+            let _ = tokio::signal::ctrl_c().await;
+        }),
+    )
+    .await
+}

--- a/apps/rmu/tests/entrypoint.rs
+++ b/apps/rmu/tests/entrypoint.rs
@@ -1,0 +1,142 @@
+use std::process::Command;
+
+#[cfg(all(
+    unix,
+    feature = "firestore-integration",
+    feature = "postgres-integration"
+))]
+use std::{
+    net::{TcpListener, TcpStream},
+    thread,
+    time::{Duration, Instant},
+};
+
+#[cfg(all(feature = "firestore-integration", feature = "postgres-integration"))]
+use testcontainers_modules::{
+    postgres::Postgres,
+    testcontainers::{ImageExt, runners::AsyncRunner},
+};
+
+#[test]
+fn rejects_missing_runtime_configuration() {
+    let missing = Command::new(env!("CARGO_BIN_EXE_morecat-rmu"))
+        .env_remove("GOOGLE_CLOUD_PROJECT")
+        .env_remove("DATABASE_URL")
+        .env_remove("PORT")
+        .output()
+        .unwrap();
+
+    assert!(!missing.status.success());
+    assert!(
+        String::from_utf8(missing.stderr)
+            .unwrap()
+            .contains("missing GOOGLE_CLOUD_PROJECT")
+    );
+
+    let invalid_database = Command::new(env!("CARGO_BIN_EXE_morecat-rmu"))
+        .env("GOOGLE_CLOUD_PROJECT", "demo-morecat")
+        .env("DATABASE_URL", "postgres://user:secret@[invalid/morecat")
+        .env("PORT", "8080")
+        .output()
+        .unwrap();
+
+    assert!(!invalid_database.status.success());
+    assert!(
+        String::from_utf8(invalid_database.stderr)
+            .unwrap()
+            .contains("failed to connect to Postgres: invalid DATABASE_URL")
+    );
+}
+
+#[cfg(all(feature = "firestore-integration", feature = "postgres-integration"))]
+#[test]
+fn initializes_live_dependencies_before_reporting_a_bind_failure() {
+    let runtime = tokio::runtime::Runtime::new().unwrap();
+    let container = runtime.block_on(async {
+        Postgres::default()
+            .with_tag("17-alpine")
+            .start()
+            .await
+            .unwrap()
+    });
+    let host = runtime.block_on(container.get_host()).unwrap();
+    let port = runtime
+        .block_on(container.get_host_port_ipv4(5432))
+        .unwrap();
+    let database_url = format!("postgres://postgres:postgres@{host}:{port}/postgres");
+    let occupied = std::net::TcpListener::bind(("0.0.0.0", 0)).unwrap();
+    let occupied_port = occupied.local_addr().unwrap().port();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_morecat-rmu"))
+        .env("GOOGLE_CLOUD_PROJECT", "demo-morecat")
+        .env("DATABASE_URL", database_url)
+        .env("PORT", occupied_port.to_string())
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    assert!(
+        String::from_utf8(output.stderr)
+            .unwrap()
+            .contains("failed to bind RMU listener")
+    );
+
+    runtime.block_on(async move { drop(container) });
+}
+
+#[cfg(all(
+    unix,
+    feature = "firestore-integration",
+    feature = "postgres-integration"
+))]
+#[test]
+fn stops_the_live_service_cleanly_on_interrupt() {
+    let runtime = tokio::runtime::Runtime::new().unwrap();
+    let container = runtime.block_on(async {
+        Postgres::default()
+            .with_tag("17-alpine")
+            .start()
+            .await
+            .unwrap()
+    });
+    let host = runtime.block_on(container.get_host()).unwrap();
+    let postgres_port = runtime
+        .block_on(container.get_host_port_ipv4(5432))
+        .unwrap();
+    let database_url = format!("postgres://postgres:postgres@{host}:{postgres_port}/postgres");
+    let port = available_port();
+    let mut child = Command::new(env!("CARGO_BIN_EXE_morecat-rmu"))
+        .env("GOOGLE_CLOUD_PROJECT", "demo-morecat")
+        .env("DATABASE_URL", database_url)
+        .env("PORT", port.to_string())
+        .spawn()
+        .unwrap();
+
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while TcpStream::connect(("127.0.0.1", port)).is_err() {
+        assert!(Instant::now() < deadline, "RMU listener did not start");
+        thread::sleep(Duration::from_millis(25));
+    }
+    let signal = Command::new("kill")
+        .args(["-INT", &child.id().to_string()])
+        .status()
+        .unwrap();
+    let status = child.wait().unwrap();
+    runtime.block_on(async move { drop(container) });
+
+    assert!(signal.success());
+    assert!(status.success());
+}
+
+#[cfg(all(
+    unix,
+    feature = "firestore-integration",
+    feature = "postgres-integration"
+))]
+fn available_port() -> u16 {
+    TcpListener::bind(("127.0.0.1", 0))
+        .unwrap()
+        .local_addr()
+        .unwrap()
+        .port()
+}

--- a/apps/rmu/tests/entrypoint.rs
+++ b/apps/rmu/tests/entrypoint.rs
@@ -90,7 +90,7 @@ fn initializes_live_dependencies_before_reporting_a_bind_failure() {
     feature = "postgres-integration"
 ))]
 #[test]
-fn stops_the_live_service_cleanly_on_interrupt() {
+fn stops_the_live_service_cleanly_on_interrupt_and_termination() {
     let runtime = tokio::runtime::Runtime::new().unwrap();
     let container = runtime.block_on(async {
         Postgres::default()
@@ -104,28 +104,35 @@ fn stops_the_live_service_cleanly_on_interrupt() {
         .block_on(container.get_host_port_ipv4(5432))
         .unwrap();
     let database_url = format!("postgres://postgres:postgres@{host}:{postgres_port}/postgres");
-    let port = available_port();
-    let mut child = Command::new(env!("CARGO_BIN_EXE_morecat-rmu"))
-        .env("GOOGLE_CLOUD_PROJECT", "demo-morecat")
-        .env("DATABASE_URL", database_url)
-        .env("PORT", port.to_string())
-        .spawn()
-        .unwrap();
+    let mut results = Vec::new();
+    for signal_name in ["-INT", "-TERM"] {
+        let port = available_port();
+        let mut child = Command::new(env!("CARGO_BIN_EXE_morecat-rmu"))
+            .env("GOOGLE_CLOUD_PROJECT", "demo-morecat")
+            .env("DATABASE_URL", &database_url)
+            .env("PORT", port.to_string())
+            .spawn()
+            .unwrap();
 
-    let deadline = Instant::now() + Duration::from_secs(10);
-    while TcpStream::connect(("127.0.0.1", port)).is_err() {
-        assert!(Instant::now() < deadline, "RMU listener did not start");
-        thread::sleep(Duration::from_millis(25));
+        let deadline = Instant::now() + Duration::from_secs(10);
+        while TcpStream::connect(("127.0.0.1", port)).is_err() {
+            assert!(Instant::now() < deadline, "RMU listener did not start");
+            thread::sleep(Duration::from_millis(25));
+        }
+        let signal = Command::new("kill")
+            .args([signal_name, &child.id().to_string()])
+            .status()
+            .unwrap();
+        let status = child.wait().unwrap();
+
+        results.push((signal_name, signal.success(), status.success()));
     }
-    let signal = Command::new("kill")
-        .args(["-INT", &child.id().to_string()])
-        .status()
-        .unwrap();
-    let status = child.wait().unwrap();
     runtime.block_on(async move { drop(container) });
 
-    assert!(signal.success());
-    assert!(status.success());
+    for (signal_name, signal_sent, stopped_cleanly) in results {
+        assert!(signal_sent);
+        assert!(stopped_cleanly, "RMU did not handle {signal_name}");
+    }
 }
 
 #[cfg(all(

--- a/apps/rmu/tests/entrypoint.rs
+++ b/apps/rmu/tests/entrypoint.rs
@@ -6,9 +6,12 @@ use std::process::Command;
     feature = "postgres-integration"
 ))]
 use std::{
-    net::{TcpListener, TcpStream},
+    io::{BufRead, BufReader},
+    net::TcpStream,
+    process::Stdio,
+    sync::mpsc,
     thread,
-    time::{Duration, Instant},
+    time::Duration,
 };
 
 #[cfg(all(feature = "firestore-integration", feature = "postgres-integration"))]
@@ -78,7 +81,7 @@ fn initializes_live_dependencies_before_reporting_a_bind_failure() {
     assert!(
         String::from_utf8(output.stderr)
             .unwrap()
-            .contains("failed to bind RMU listener")
+            .contains("failed to bind RMU listener: address already in use")
     );
 
     runtime.block_on(async move { drop(container) });
@@ -106,18 +109,26 @@ fn stops_the_live_service_cleanly_on_interrupt_and_termination() {
     let database_url = format!("postgres://postgres:postgres@{host}:{postgres_port}/postgres");
     let mut results = Vec::new();
     for signal_name in ["-INT", "-TERM"] {
-        let port = available_port();
         let mut child = Command::new(env!("CARGO_BIN_EXE_morecat-rmu"))
             .env("GOOGLE_CLOUD_PROJECT", "demo-morecat")
             .env("DATABASE_URL", &database_url)
-            .env("PORT", port.to_string())
+            .env("PORT", "0")
+            .stdout(Stdio::piped())
             .spawn()
             .unwrap();
 
-        let deadline = Instant::now() + Duration::from_secs(10);
-        while TcpStream::connect(("127.0.0.1", port)).is_err() {
-            assert!(Instant::now() < deadline, "RMU listener did not start");
-            thread::sleep(Duration::from_millis(25));
+        let readiness = readiness_port(child.stdout.take().unwrap());
+        let Ok(port) = readiness.recv_timeout(Duration::from_secs(10)) else {
+            child.kill().unwrap();
+            child.wait().unwrap();
+            results.push((signal_name, false, false));
+            break;
+        };
+        if TcpStream::connect(("127.0.0.1", port)).is_err() {
+            child.kill().unwrap();
+            child.wait().unwrap();
+            results.push((signal_name, false, false));
+            break;
         }
         let signal = Command::new("kill")
             .args([signal_name, &child.id().to_string()])
@@ -130,7 +141,10 @@ fn stops_the_live_service_cleanly_on_interrupt_and_termination() {
     runtime.block_on(async move { drop(container) });
 
     for (signal_name, signal_sent, stopped_cleanly) in results {
-        assert!(signal_sent);
+        assert!(
+            signal_sent,
+            "RMU did not report readiness for {signal_name}"
+        );
         assert!(stopped_cleanly, "RMU did not handle {signal_name}");
     }
 }
@@ -140,10 +154,18 @@ fn stops_the_live_service_cleanly_on_interrupt_and_termination() {
     feature = "firestore-integration",
     feature = "postgres-integration"
 ))]
-fn available_port() -> u16 {
-    TcpListener::bind(("127.0.0.1", 0))
-        .unwrap()
-        .local_addr()
-        .unwrap()
-        .port()
+fn readiness_port(stdout: impl std::io::Read + Send + 'static) -> mpsc::Receiver<u16> {
+    let (sender, receiver) = mpsc::channel();
+    thread::spawn(move || {
+        let mut line = String::new();
+        BufReader::new(stdout).read_line(&mut line).unwrap();
+        if let Some(port) = line
+            .trim()
+            .strip_prefix("RMU listening on 0.0.0.0:")
+            .and_then(|port| port.parse().ok())
+        {
+            sender.send(port).unwrap();
+        }
+    });
+    receiver
 }


### PR DESCRIPTION
## Summary

- add the RMU production binary and bind the axum service to Cloud Run's `PORT`
- initialize the live Firestore and Postgres adapters from runtime configuration
- gracefully stop on `SIGINT` and redact listener/server failure details
- cover configuration, dependency initialization, bind failures, and the real binary lifecycle
- document required environment variables and local startup

## Context

This continues slice 1 task 3 by making the existing RMU router runnable as a Cloud Run service. The entrypoint uses the same live adapter wiring exercised by the Firestore emulator and Postgres Testcontainers integration suite.

## Review setup

Docker must be running. From the repository root:

```sh
export DOCKER_HOST="$(docker context inspect --format '{{.Endpoints.docker.Host}}')"
firebase emulators:exec \
  --config apps/api/firebase.json \
  --only firestore \
  --project demo-morecat \
  'cargo llvm-cov --manifest-path apps/rmu/Cargo.toml --locked --all-features --fail-under-lines 100 --fail-under-regions 100'
```

## Validation

- `cargo fmt --manifest-path apps/rmu/Cargo.toml --check`
- `cargo clippy --manifest-path apps/rmu/Cargo.toml --locked --all-targets --all-features -- -D warnings`
- full Firestore emulator + Postgres Testcontainers suite: 56 tests passed
- line coverage: 100%
- region coverage: 100%