### PR TITLE
Add RMU manual replay command

### DIFF
--- a/apps/rmu/README.md
+++ b/apps/rmu/README.md
@@ -46,6 +46,22 @@ cargo run --manifest-path apps/rmu/Cargo.toml
 
 終了時は両ターミナルで `Ctrl-C` を入力する。
 
+## Manual replay
+
+`replay` command は Firestore の全 `events` subcollection を collection-group query で列挙し、article ID ごとに全 event stream を再読込して Postgres projection を更新する。HTTP listener は起動せず、最初の読み取り・projection エラーで非ゼロ終了する。
+
+```sh
+# repository root
+FIRESTORE_EMULATOR_HOST=127.0.0.1:8080 \
+GOOGLE_CLOUD_PROJECT=demo-morecat \
+DATABASE_URL=postgres://morecat:local-dev-password@127.0.0.1:5432/morecat \
+cargo run --manifest-path apps/rmu/Cargo.toml -- replay
+```
+
+成功時は `Replayed N article(s)` を出力する。本番では同じ container image の command を `replay` に上書きした Cloud Run Job として実行できる。
+
+通常の再送・追いつき用途では `last_applied_seq` が進む projection だけを更新するため、繰り返し実行できる。完全再構築では migration 適用済みの空の Postgres database を対象にする。command 自体は `articles` table の削除や `TRUNCATE` を行わないため、既存 database を初期化する場合は backup と切り戻し手順を別途用意してから実施する。
+
 ## Development
 
 リポジトリルートで Rust 用 dev shell に入り、テストを実行する。

--- a/apps/rmu/src/bootstrap.rs
+++ b/apps/rmu/src/bootstrap.rs
@@ -11,6 +11,7 @@ use crate::{
     firestore_stream::{FirestoreEventStreamReader, GoogleFirestoreEventDocuments},
     postgres::{PostgresArticleProjectionStore, PostgresDeadLetterStore},
     processor::RmuEventActions,
+    replay::{ArticleReplay, ReplayError},
 };
 
 #[derive(Clone, PartialEq, Eq)]
@@ -18,6 +19,22 @@ pub struct RmuConfig {
     pub project_id: String,
     pub database_url: String,
     pub port: u16,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RmuCommand {
+    Serve,
+    Replay,
+}
+
+impl RmuCommand {
+    pub fn from_args(args: Vec<OsString>) -> Result<Self, String> {
+        match args.as_slice() {
+            [] => Ok(Self::Serve),
+            [command] if command == "replay" => Ok(Self::Replay),
+            _ => Err("usage: morecat-rmu [replay]".to_owned()),
+        }
+    }
 }
 
 impl fmt::Debug for RmuConfig {
@@ -62,17 +79,7 @@ fn required_var(vars: &HashMap<OsString, OsString>, name: &str) -> Result<String
 }
 
 pub async fn build_live_router(config: RmuConfig) -> Result<Router, String> {
-    let connect_options: PgConnectOptions = config
-        .database_url
-        .parse()
-        .map_err(|_| "failed to connect to Postgres: invalid DATABASE_URL".to_owned())?;
-    let documents = GoogleFirestoreEventDocuments::new(&config.project_id)
-        .await
-        .map_err(|error| format!("failed to create Firestore client: {error}"))?;
-    let pool = PgPoolOptions::new()
-        .connect_with(connect_options)
-        .await
-        .map_err(|_| "failed to connect to Postgres".to_owned())?;
+    let (documents, pool) = connect_live_dependencies(&config).await?;
     let actions: Arc<dyn EventActions> = Arc::new(RmuEventActions::new(
         Arc::new(FirestoreEventStreamReader::new(documents)),
         Arc::new(PostgresArticleProjectionStore::new(pool.clone())),
@@ -102,6 +109,52 @@ pub async fn run(
         .with_graceful_shutdown(shutdown)
         .await
         .map_err(server_error)
+}
+
+pub async fn run_replay(vars: Vec<(OsString, OsString)>) -> Result<usize, String> {
+    let config = RmuConfig::from_vars(vars)?;
+    let (documents, pool) = connect_live_dependencies(&config).await?;
+    let projector = RmuEventActions::new(
+        Arc::new(FirestoreEventStreamReader::new(documents.clone())),
+        Arc::new(PostgresArticleProjectionStore::new(pool.clone())),
+        Arc::new(PostgresDeadLetterStore::new(pool)),
+    );
+
+    ArticleReplay::new(documents, projector)
+        .replay_all()
+        .await
+        .map_err(replay_error)
+}
+
+async fn connect_live_dependencies(
+    config: &RmuConfig,
+) -> Result<(GoogleFirestoreEventDocuments, sqlx::PgPool), String> {
+    let connect_options: PgConnectOptions =
+        config.database_url.parse().map_err(invalid_database_url)?;
+    let documents = GoogleFirestoreEventDocuments::new(&config.project_id)
+        .await
+        .map_err(firestore_client_error)?;
+    let pool = PgPoolOptions::new()
+        .connect_with(connect_options)
+        .await
+        .map_err(postgres_connection_error)?;
+    Ok((documents, pool))
+}
+
+fn invalid_database_url(_error: sqlx::Error) -> String {
+    "failed to connect to Postgres: invalid DATABASE_URL".to_owned()
+}
+
+fn firestore_client_error(error: String) -> String {
+    format!("failed to create Firestore client: {error}")
+}
+
+fn postgres_connection_error(_error: sqlx::Error) -> String {
+    "failed to connect to Postgres".to_owned()
+}
+
+fn replay_error(error: ReplayError) -> String {
+    format!("replay failed: {error:?}")
 }
 
 fn listener_error(error: std::io::Error) -> String {
@@ -142,6 +195,19 @@ mod tests {
                 database_url: "postgres://user:password@localhost/morecat".to_owned(),
                 port: 8080,
             })
+        );
+    }
+
+    #[test]
+    fn selects_the_service_or_replay_command() {
+        assert_eq!(RmuCommand::from_args(Vec::new()), Ok(RmuCommand::Serve));
+        assert_eq!(
+            RmuCommand::from_args(vec!["replay".into()]),
+            Ok(RmuCommand::Replay)
+        );
+        assert_eq!(
+            RmuCommand::from_args(vec!["unknown".into()]),
+            Err("usage: morecat-rmu [replay]".to_owned())
         );
     }
 
@@ -247,6 +313,28 @@ mod tests {
         assert_eq!(
             server_error(std::io::Error::other("server secret")),
             "RMU server failed"
+        );
+    }
+
+    #[test]
+    fn maps_live_dependency_and_replay_errors() {
+        assert_eq!(
+            invalid_database_url(sqlx::Error::PoolClosed),
+            "failed to connect to Postgres: invalid DATABASE_URL"
+        );
+        assert_eq!(
+            firestore_client_error("client failed".to_owned()),
+            "failed to create Firestore client: client failed"
+        );
+        assert_eq!(
+            postgres_connection_error(sqlx::Error::PoolClosed),
+            "failed to connect to Postgres"
+        );
+        assert_eq!(
+            replay_error(ReplayError::Catalog(
+                crate::firestore_stream::StreamReadError::Unavailable("query failed".to_owned())
+            )),
+            "replay failed: Catalog(Unavailable(\"query failed\"))"
         );
     }
 }
@@ -410,9 +498,58 @@ mod integration_tests {
         );
     }
 
+    #[tokio::test]
+    async fn replays_all_firestore_articles_into_postgres() {
+        let (_container, pool, database_url) = migrated_postgres().await;
+        let project_id = "demo-morecat-replay";
+        seed_replay_event(project_id).await;
+
+        let result = run_replay(vec![
+            ("GOOGLE_CLOUD_PROJECT".into(), project_id.into()),
+            ("DATABASE_URL".into(), database_url.into()),
+        ])
+        .await;
+        assert_eq!(result, Ok(1));
+
+        let row: (String, String, i64) = sqlx::query_as(
+            "SELECT status, slug, last_applied_seq FROM articles WHERE article_id = $1",
+        )
+        .bind(ARTICLE_ID)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+        assert_eq!(row, ("draft".to_owned(), "hello-world".to_owned(), 1));
+    }
+
     async fn seed_draft_event() {
         let article_id = Uuid::parse_str(ARTICLE_ID).unwrap();
         let documents = GoogleFirestoreEventDocuments::new("demo-morecat")
+            .await
+            .unwrap();
+        let parent = documents
+            .database()
+            .parent_path("articles", article_id.to_string())
+            .unwrap();
+        documents
+            .database()
+            .fluent()
+            .insert()
+            .into("events")
+            .document_id("1")
+            .parent(&parent)
+            .object(&EventFields {
+                json: r#"{"eventType":"ArticleDrafted","schemaVersion":1,"slug":"hello-world","title":"Hello","body":"Body"}"#
+                    .to_owned(),
+            })
+            .execute::<EventFields>()
+            .await
+            .unwrap();
+    }
+
+    async fn seed_replay_event(project_id: &str) {
+        let article_id = Uuid::parse_str(ARTICLE_ID).unwrap();
+        let documents = GoogleFirestoreEventDocuments::new(project_id)
             .await
             .unwrap();
         let parent = documents

--- a/apps/rmu/src/firestore_stream.rs
+++ b/apps/rmu/src/firestore_stream.rs
@@ -4,11 +4,12 @@ use firestore::{FirestoreDb, FirestoreDbOptions, firestore_document_to_serializa
 use futures::TryStreamExt;
 use gcloud_sdk::{SecretValue, Source, Token, TokenSourceType};
 use serde::Deserialize;
+use std::collections::BTreeSet;
 use std::ffi::OsString;
 use std::time::{Duration, SystemTime};
 use uuid::Uuid;
 
-use crate::{parse_document_name, projection::StoredArticleEvent};
+use crate::{parse_document_name, projection::StoredArticleEvent, replay::ArticleCatalog};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FirestoreEventDocument {
@@ -30,6 +31,7 @@ pub trait FirestoreEventDocuments: Send + Sync {
     ) -> Result<Vec<FirestoreEventDocument>, StreamReadError>;
 }
 
+#[derive(Clone)]
 pub struct GoogleFirestoreEventDocuments {
     db: FirestoreDb,
 }
@@ -105,6 +107,16 @@ fn firestore_unavailable(error: FirestoreError) -> StreamReadError {
     StreamReadError::Unavailable(firestore_error_message(error))
 }
 
+fn article_ids_from_document_names(names: Vec<String>) -> Result<Vec<Uuid>, StreamReadError> {
+    let mut article_ids = BTreeSet::new();
+    for name in names {
+        let document = parse_document_name(&name)
+            .map_err(|_| StreamReadError::InvalidDocument(name.clone()))?;
+        article_ids.insert(document.article_id);
+    }
+    Ok(article_ids.into_iter().collect())
+}
+
 #[async_trait]
 impl FirestoreEventDocuments for GoogleFirestoreEventDocuments {
     async fn load_event_documents(
@@ -139,6 +151,28 @@ impl FirestoreEventDocuments for GoogleFirestoreEventDocuments {
                 })
             })
             .collect()
+    }
+}
+
+#[async_trait]
+impl ArticleCatalog for GoogleFirestoreEventDocuments {
+    async fn list_article_ids(&self) -> Result<Vec<Uuid>, StreamReadError> {
+        let stream = self
+            .db
+            .fluent()
+            .select()
+            .from("events")
+            .all_descendants()
+            .stream_query_with_errors()
+            .await
+            .map_err(firestore_unavailable)?;
+        let documents: Vec<_> = stream.try_collect().await.map_err(firestore_unavailable)?;
+        article_ids_from_document_names(
+            documents
+                .into_iter()
+                .map(|document| document.name)
+                .collect(),
+        )
     }
 }
 
@@ -236,6 +270,32 @@ mod tests {
                 "Data not found error occurred: Invalid parameters error: article_id. invalid"
                     .to_owned()
             )
+        );
+    }
+
+    #[test]
+    fn extracts_unique_article_ids_from_event_document_names() {
+        let first = Uuid::parse_str("018f4edc-1f5a-7c4b-aef9-000000000001").unwrap();
+        let second = Uuid::parse_str("018f4edc-1f5a-7c4b-aef9-000000000002").unwrap();
+        let name = |article_id: Uuid, seq: u64| {
+            format!(
+                "projects/demo-morecat/databases/(default)/documents/articles/{article_id}/events/{seq}"
+            )
+        };
+
+        let result =
+            article_ids_from_document_names(vec![name(second, 1), name(first, 2), name(first, 1)]);
+
+        assert_eq!(result, Ok(vec![first, second]));
+    }
+
+    #[test]
+    fn rejects_invalid_event_document_names_during_catalog_listing() {
+        let name = "projects/demo-morecat/databases/(default)/documents/slugs/hello".to_owned();
+
+        assert_eq!(
+            article_ids_from_document_names(vec![name.clone()]),
+            Err(StreamReadError::InvalidDocument(name))
         );
     }
 
@@ -365,6 +425,40 @@ mod tests {
                 document(article_id, 2, "published"),
             ]
         );
+    }
+
+    #[cfg(feature = "firestore-integration")]
+    #[tokio::test]
+    async fn lists_unique_article_ids_across_event_subcollections() {
+        let first = Uuid::parse_str("018f4edc-1f5a-7c4b-aef9-000000000013").unwrap();
+        let second = Uuid::parse_str("018f4edc-1f5a-7c4b-aef9-000000000014").unwrap();
+        let documents = GoogleFirestoreEventDocuments::new("demo-morecat")
+            .await
+            .unwrap();
+        for (article_id, seq) in [(first, "1"), (first, "2"), (second, "1")] {
+            let parent = documents
+                .db
+                .parent_path("articles", article_id.to_string())
+                .unwrap();
+            documents
+                .db
+                .fluent()
+                .insert()
+                .into("events")
+                .document_id(seq)
+                .parent(&parent)
+                .object(&SeedEventFields {
+                    json: "event".to_owned(),
+                })
+                .execute::<SeedEventFields>()
+                .await
+                .unwrap();
+        }
+
+        let result = documents.list_article_ids().await.unwrap();
+
+        assert_eq!(result.iter().filter(|id| **id == first).count(), 1);
+        assert_eq!(result.iter().filter(|id| **id == second).count(), 1);
     }
 
     #[cfg(feature = "firestore-integration")]

--- a/apps/rmu/src/lib.rs
+++ b/apps/rmu/src/lib.rs
@@ -6,6 +6,7 @@ pub mod firestore_stream;
 pub mod postgres;
 pub mod processor;
 pub mod projection;
+pub mod replay;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct EventDocument {

--- a/apps/rmu/src/main.rs
+++ b/apps/rmu/src/main.rs
@@ -1,6 +1,18 @@
 #[tokio::main]
 async fn main() -> Result<(), String> {
-    morecat_rmu::bootstrap::run(std::env::vars_os().collect(), Box::pin(shutdown_signal())).await
+    let command =
+        morecat_rmu::bootstrap::RmuCommand::from_args(std::env::args_os().skip(1).collect())?;
+    let vars = std::env::vars_os().collect();
+    match command {
+        morecat_rmu::bootstrap::RmuCommand::Serve => {
+            morecat_rmu::bootstrap::run(vars, Box::pin(shutdown_signal())).await
+        }
+        morecat_rmu::bootstrap::RmuCommand::Replay => {
+            let count = morecat_rmu::bootstrap::run_replay(vars).await?;
+            println!("Replayed {count} article(s)");
+            Ok(())
+        }
+    }
 }
 
 #[cfg(unix)]

--- a/apps/rmu/src/processor.rs
+++ b/apps/rmu/src/processor.rs
@@ -7,6 +7,7 @@ use crate::{
     eventarc::{AcceptedEvent, DeadLetter, EventActions, ProcessingError},
     firestore_stream::{FirestoreEventDocuments, FirestoreEventStreamReader, StreamReadError},
     projection::{ArticleProjection, StoredArticleEvent, project_article},
+    replay::ArticleProjector,
 };
 
 #[async_trait]
@@ -52,14 +53,13 @@ impl<S, P, D> RmuEventActions<S, P, D> {
 }
 
 #[async_trait]
-impl<S, P, D> EventActions for RmuEventActions<S, P, D>
+impl<S, P, D> ArticleProjector for RmuEventActions<S, P, D>
 where
     S: ArticleEventStream,
     P: ArticleProjectionStore,
     D: DeadLetterStore,
 {
-    async fn process(&self, event: AcceptedEvent) -> Result<(), ProcessingError> {
-        let article_id = event.document.article_id;
+    async fn project(&self, article_id: Uuid) -> Result<(), ProcessingError> {
         let events = self
             .stream
             .load(article_id)
@@ -77,6 +77,18 @@ where
             .map_err(|error| {
                 ProcessingError::Transient(format!("projection upsert failed: {error}"))
             })
+    }
+}
+
+#[async_trait]
+impl<S, P, D> EventActions for RmuEventActions<S, P, D>
+where
+    S: ArticleEventStream,
+    P: ArticleProjectionStore,
+    D: DeadLetterStore,
+{
+    async fn process(&self, event: AcceptedEvent) -> Result<(), ProcessingError> {
+        self.project(event.document.article_id).await
     }
 
     async fn record_dead_letter(&self, dead_letter: DeadLetter) -> Result<(), String> {
@@ -174,7 +186,7 @@ mod tests {
             projections.clone(),
             Arc::new(RecordingDeadLetterStore::default()),
         );
-        let result = actions.process(accepted_event(article_id)).await;
+        let result = ArticleProjector::project(&actions, article_id).await;
 
         assert_eq!(result, Ok(()));
         assert_eq!(

--- a/apps/rmu/src/replay.rs
+++ b/apps/rmu/src/replay.rs
@@ -1,0 +1,172 @@
+use async_trait::async_trait;
+use uuid::Uuid;
+
+use crate::{eventarc::ProcessingError, firestore_stream::StreamReadError};
+
+#[async_trait]
+pub trait ArticleCatalog: Send + Sync {
+    async fn list_article_ids(&self) -> Result<Vec<Uuid>, StreamReadError>;
+}
+
+#[async_trait]
+pub trait ArticleProjector: Send + Sync {
+    async fn project(&self, article_id: Uuid) -> Result<(), ProcessingError>;
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ReplayError {
+    Catalog(StreamReadError),
+    Article {
+        article_id: Uuid,
+        error: ProcessingError,
+    },
+}
+
+pub struct ArticleReplay<C, P> {
+    catalog: C,
+    projector: P,
+}
+
+impl<C, P> ArticleReplay<C, P> {
+    pub fn new(catalog: C, projector: P) -> Self {
+        Self { catalog, projector }
+    }
+}
+
+impl<C, P> ArticleReplay<C, P>
+where
+    C: ArticleCatalog,
+    P: ArticleProjector,
+{
+    pub async fn replay_all(&self) -> Result<usize, ReplayError> {
+        let article_ids = self
+            .catalog
+            .list_article_ids()
+            .await
+            .map_err(ReplayError::Catalog)?;
+        for article_id in &article_ids {
+            self.projector
+                .project(*article_id)
+                .await
+                .map_err(|error| ReplayError::Article {
+                    article_id: *article_id,
+                    error,
+                })?;
+        }
+        Ok(article_ids.len())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex;
+
+    use super::*;
+
+    const FIRST_ARTICLE_ID: &str = "018f4edc-1f5a-7c4b-aef9-000000000001";
+    const SECOND_ARTICLE_ID: &str = "018f4edc-1f5a-7c4b-aef9-000000000002";
+
+    struct StubCatalog {
+        article_ids: Vec<Uuid>,
+        error: Option<StreamReadError>,
+    }
+
+    #[async_trait]
+    impl ArticleCatalog for StubCatalog {
+        async fn list_article_ids(&self) -> Result<Vec<Uuid>, StreamReadError> {
+            match &self.error {
+                Some(error) => Err(error.clone()),
+                None => Ok(self.article_ids.clone()),
+            }
+        }
+    }
+
+    #[derive(Default)]
+    struct RecordingProjector {
+        article_ids: Mutex<Vec<Uuid>>,
+        error_for: Option<Uuid>,
+    }
+
+    #[async_trait]
+    impl ArticleProjector for RecordingProjector {
+        async fn project(&self, article_id: Uuid) -> Result<(), ProcessingError> {
+            if self.error_for == Some(article_id) {
+                return Err(ProcessingError::Transient("projection failed".to_owned()));
+            }
+            self.article_ids.lock().unwrap().push(article_id);
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn replays_every_article_and_reports_the_count() {
+        let article_ids = vec![article_id(FIRST_ARTICLE_ID), article_id(SECOND_ARTICLE_ID)];
+        let projector = RecordingProjector::default();
+        let replay = ArticleReplay::new(
+            StubCatalog {
+                article_ids: article_ids.clone(),
+                error: None,
+            },
+            projector,
+        );
+
+        let result = replay.replay_all().await;
+
+        assert_eq!(result, Ok(2));
+        assert_eq!(*replay.projector.article_ids.lock().unwrap(), article_ids);
+    }
+
+    #[tokio::test]
+    async fn preserves_catalog_and_article_failures() {
+        let first = article_id(FIRST_ARTICLE_ID);
+        let second = article_id(SECOND_ARTICLE_ID);
+        let catalog_error = StreamReadError::Unavailable("catalog failed".to_owned());
+        let unavailable = ArticleReplay::new(
+            StubCatalog {
+                article_ids: Vec::new(),
+                error: Some(catalog_error.clone()),
+            },
+            RecordingProjector::default(),
+        );
+        assert_eq!(
+            unavailable.replay_all().await,
+            Err(ReplayError::Catalog(catalog_error))
+        );
+
+        let failing = ArticleReplay::new(
+            StubCatalog {
+                article_ids: vec![first, second],
+                error: None,
+            },
+            RecordingProjector {
+                error_for: Some(second),
+                ..RecordingProjector::default()
+            },
+        );
+        assert_eq!(
+            failing.replay_all().await,
+            Err(ReplayError::Article {
+                article_id: second,
+                error: ProcessingError::Transient("projection failed".to_owned()),
+            })
+        );
+        assert_eq!(*failing.projector.article_ids.lock().unwrap(), vec![first]);
+    }
+
+    #[tokio::test]
+    async fn accepts_an_empty_catalog() {
+        let replay = ArticleReplay::new(
+            StubCatalog {
+                article_ids: Vec::new(),
+                error: None,
+            },
+            RecordingProjector::default(),
+        );
+
+        assert_eq!(replay.replay_all().await, Ok(0));
+    }
+
+    fn article_id(value: &str) -> Uuid {
+        Uuid::parse_str(value).unwrap()
+    }
+}

--- a/apps/rmu/tests/entrypoint.rs
+++ b/apps/rmu/tests/entrypoint.rs
@@ -22,6 +22,17 @@ use testcontainers_modules::{
 
 #[test]
 fn rejects_missing_runtime_configuration() {
+    let unknown_command = Command::new(env!("CARGO_BIN_EXE_morecat-rmu"))
+        .arg("unknown")
+        .output()
+        .unwrap();
+    assert!(!unknown_command.status.success());
+    assert!(
+        String::from_utf8(unknown_command.stderr)
+            .unwrap()
+            .contains("usage: morecat-rmu [replay]")
+    );
+
     let missing = Command::new(env!("CARGO_BIN_EXE_morecat-rmu"))
         .env_remove("GOOGLE_CLOUD_PROJECT")
         .env_remove("DATABASE_URL")
@@ -34,6 +45,33 @@ fn rejects_missing_runtime_configuration() {
         String::from_utf8(missing.stderr)
             .unwrap()
             .contains("missing GOOGLE_CLOUD_PROJECT")
+    );
+
+    let missing_replay = Command::new(env!("CARGO_BIN_EXE_morecat-rmu"))
+        .arg("replay")
+        .env_remove("GOOGLE_CLOUD_PROJECT")
+        .env_remove("DATABASE_URL")
+        .env_remove("PORT")
+        .output()
+        .unwrap();
+    assert!(!missing_replay.status.success());
+    assert!(
+        String::from_utf8(missing_replay.stderr)
+            .unwrap()
+            .contains("missing GOOGLE_CLOUD_PROJECT")
+    );
+
+    let invalid_replay_database = Command::new(env!("CARGO_BIN_EXE_morecat-rmu"))
+        .arg("replay")
+        .env("GOOGLE_CLOUD_PROJECT", "demo-morecat")
+        .env("DATABASE_URL", "postgres://user:secret@[invalid/morecat")
+        .output()
+        .unwrap();
+    assert!(!invalid_replay_database.status.success());
+    assert!(
+        String::from_utf8(invalid_replay_database.stderr)
+            .unwrap()
+            .contains("failed to connect to Postgres: invalid DATABASE_URL")
     );
 
     let invalid_database = Command::new(env!("CARGO_BIN_EXE_morecat-rmu"))
@@ -85,6 +123,41 @@ fn initializes_live_dependencies_before_reporting_a_bind_failure() {
     );
 
     runtime.block_on(async move { drop(container) });
+}
+
+#[cfg(all(feature = "firestore-integration", feature = "postgres-integration"))]
+#[test]
+fn runs_replay_without_starting_the_http_listener() {
+    let runtime = tokio::runtime::Runtime::new().unwrap();
+    let container = runtime.block_on(async {
+        Postgres::default()
+            .with_tag("17-alpine")
+            .start()
+            .await
+            .unwrap()
+    });
+    let host = runtime.block_on(container.get_host()).unwrap();
+    let postgres_port = runtime
+        .block_on(container.get_host_port_ipv4(5432))
+        .unwrap();
+    let database_url = format!("postgres://postgres:postgres@{host}:{postgres_port}/postgres");
+    let occupied = std::net::TcpListener::bind(("0.0.0.0", 0)).unwrap();
+    let occupied_port = occupied.local_addr().unwrap().port();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_morecat-rmu"))
+        .arg("replay")
+        .env("GOOGLE_CLOUD_PROJECT", "demo-morecat-empty-replay")
+        .env("DATABASE_URL", database_url)
+        .env("PORT", occupied_port.to_string())
+        .output()
+        .unwrap();
+    runtime.block_on(async move { drop(container) });
+
+    assert!(output.status.success());
+    assert_eq!(
+        String::from_utf8(output.stdout).unwrap(),
+        "Replayed 0 article(s)\n"
+    );
 }
 
 #[cfg(all(


### PR DESCRIPTION
## Summary

- add an application service that replays every catalogued article through the existing stream load, fold, and projection path
- discover unique article IDs with a Firestore `events` collection-group query
- add a `replay` command to the existing RMU binary for local use or a Cloud Run Job command override
- fail fast with typed catalog/article errors and retain `last_applied_seq` idempotency
- document catch-up and full-rebuild operating procedures without automatically truncating Postgres

## Context

This completes the manual replay requirement in slice 1 task 3. The replay path shares `RmuEventActions` with Eventarc processing, so online delivery and manual rebuilding use the same projection semantics.

## Review setup

Docker must be running. From the repository root:

```sh
export DOCKER_HOST="$(docker context inspect --format '{{.Endpoints.docker.Host}}')"
firebase emulators:exec \
  --config apps/api/firebase.json \
  --only firestore \
  --project demo-morecat \
  'cargo llvm-cov --manifest-path apps/rmu/Cargo.toml --locked --all-features --fail-under-lines 100 --fail-under-regions 100'
```

## Validation

- `cargo fmt --manifest-path apps/rmu/Cargo.toml --check`
- `cargo clippy --manifest-path apps/rmu/Cargo.toml --locked --all-targets --all-features -- -D warnings`
- full Firestore emulator + Postgres Testcontainers suite: 66 tests passed
- line coverage: 100%
- region coverage: 100%